### PR TITLE
Smarter Handling of casing in directory names

### DIFF
--- a/src/bundle-files.js
+++ b/src/bundle-files.js
@@ -146,15 +146,17 @@ BundleFiles.prototype.getFilesInDirectory = function (fileType, bundleDir, curre
         dictionary = fileType == exports.BundleType.Javascript ? _this._jsDirectories : _this._cssDirectories
         output = [];
 
-    if (!_this.indexed) { throw new Error("Files are not indexed!") };
+    if (!_this.indexed) { throw new Error("Files must be indexed before looking up directories.") };
 
     var dictEntry = bundleDir.NormalizeSlash(true, true).toLowerCase();
     bundleDir = bundleDir.NormalizeSlash(false, true).toLowerCase();
     currentDir = currentDir.NormalizeSlash(false, true);
 
-    var files = 
+    var files = dictionary[dictEntry] || [];
 
-    (dictionary[dictEntry] || []).forEach(function (name) {
+    if (files.length == 0) { throw new Error("No files found for directory: " + bundleDir) };
+
+    files.forEach(function (name) {
 
         var match = currentDir + '/' + matcher(name, bundleDir, true);
 

--- a/src/jasmine-tests/bundle-files-spec.js
+++ b/src/jasmine-tests/bundle-files-spec.js
@@ -166,6 +166,18 @@ describe("BundleFiles.", function () {
           expect(jsFilesInDir.length).toBe(1);
           expect(jsFilesInDir.contains("output/file.js")).toBe(true);
       });
+
+      it("Throws if no files found for directory", function () {
+
+          var shouldThrow = function () {
+              files.getFilesInDirectory(bundlefiles.BundleType.Javascript,
+                                      "/not_a_valid_directory",
+                                      "output"
+                                  );
+          };
+
+          expect(shouldThrow).toThrow();
+      });
   });
 
   describe("getFilesInDirectory: - Css: ", function () {
@@ -244,6 +256,18 @@ describe("BundleFiles.", function () {
 
           expect(cssFilesInDir.length).toBe(1);
           expect(cssFilesInDir.contains("output/file.css")).toBe(true);
+      });
+
+      it("Throws if no files found for directory", function () {
+
+          var shouldThrow = function () {
+              files.getFilesInDirectory(bundlefiles.BundleType.Css,
+                                      "/not_a_valid_directory",
+                                      "output"
+                                  );
+          };
+
+          expect(shouldThrow).toThrow();
       });
   });
 });


### PR DESCRIPTION
@thomas-huston-zocdoc @Laura-Johannet-ZocDoc
# Description

This makes the the bundle files a little more forgiving by not requiring the casing to exactly match the directory on disk.  Plus it blows up more explicitly if you put in a bogus directory.
