### PR TITLE
Clear out localized strings on re-bundle

### DIFF
--- a/src/bundle-stats.js
+++ b/src/bundle-stats.js
@@ -152,9 +152,9 @@ var parseAndAddToCollection = function(bundleName, text, collection, parseRegex,
 var clearCollection = function(name, collection) {
     var bundleShortName = name.split('/').pop();
 
-    if (collection[name])
+    if (collection[bundleShortName])
     {
-        collection[name] = [];
+        collection[bundleShortName] = [];
     }
 };
 

--- a/src/jasmine-tests/bundle-stats/bs-add-localization-file-spec.js
+++ b/src/jasmine-tests/bundle-stats/bs-add-localization-file-spec.js
@@ -78,7 +78,6 @@ describe("BundleStatsCollector - ", function() {
         expect(stats.LocalizedStrings[bundle1]).toBe(undefined);
     });
 
-
     it("Clearing a bundle removes all LocalizedStrings.", function() {
 
         stats.ParseMustacheForStats(bundle1, ls1);
@@ -91,6 +90,17 @@ describe("BundleStatsCollector - ", function() {
         validateBundle(bundle1, [ ]);
     });
 
+    it("Clearing a bundle with a path removes all LocalizedStrings.", function() {
+
+        stats.ParseMustacheForStats(bundle1, ls1);
+        stats.ParseMustacheForStats(bundle1, ls2);
+
+        validateBundle(bundle1, [ string1, string2 ]);
+
+        stats.ClearStatsForBundle("file/path/" + bundle1);
+
+        validateBundle(bundle1, [ ]);
+    });
 
     it("Duplicate LocalizedStrings are not added.", function() {
 


### PR DESCRIPTION
This fixes a bug where it was not properly handling the clearing action when the bundle name was prefaced with a file path.
