### PR TITLE
Options for directory-organized templates

### DIFF
--- a/src/bundler.js
+++ b/src/bundler.js
@@ -497,7 +497,7 @@ function getOrCreateJsMustache(options, mustacheText, mPath, jsPath, cb /*cb(js)
 
 	compileAsync(options, "compiling", function (mustacheText, mPath, cb) {
             var templateName = path.basename(mPath, path.extname(mPath)); 
-			if (options.usetemplatedirs){
+            if (options.usetemplatedirs){
                 var splitPath = mPath.replace(".mustache", "").split(path.sep);
                 var templateIndex = splitPath.indexOf("templates");
                 templateName = splitPath.slice(templateIndex + 1).join("-");


### PR DESCRIPTION
### Options for directory-organized templates

@Andrew-Hagedorn-ZocDoc 

If you have a template called `.../modules/provider/core/templates/notifications/mynotification.mustache`, having this option on will register it with `JST` as `notifications-mynotification` instead of just `mynotification`. Provider owns a lot of templates so this feature comes in handy.
