### PR TITLE
add in an optional prefix for the bundle stats files.

### DIFF
--- a/src/bundle-stats.js
+++ b/src/bundle-stats.js
@@ -57,6 +57,7 @@ function BundleStatsCollector(
     this.LessImportRegexEnd = new RegExp("(\"|')\\)", "gim");
 
     this.Console = { log: function () { } };
+    this.Prefix = '';
 }
 
 exports.BundleStatsCollector = BundleStatsCollector;
@@ -73,6 +74,14 @@ var GetOutputFile = function (outputdirectory, filename) {
     }
     return outputdirectory + seperator + filename;
 }
+
+BundleStatsCollector.prototype.setFilePrefix = function(prefix) {
+    this.Prefix = prefix;
+};
+
+var getFileName = function(collector, fileName) {
+    return collector.Prefix + fileName;
+};
 
 BundleStatsCollector.prototype.LoadStatsFromDisk = function (outputdirectory) {
 
@@ -91,11 +100,11 @@ BundleStatsCollector.prototype.LoadStatsFromDisk = function (outputdirectory) {
         return ret;
     }
 
-    _this.HashCollection = loadFromDisk(_this.FileSystem, outputdirectory, HASH_FILE_NAME);
-    _this.DebugCollection = loadFromDisk(_this.FileSystem, outputdirectory, DEBUG_FILE_NAME);
-    _this.LocalizedStrings = loadFromDisk(_this.FileSystem, outputdirectory, LOCALIZATION_FILE_NAME);
-    _this.AbConfigs = loadFromDisk(_this.FileSystem, outputdirectory, AB_FILE_NAME);
-    _this.LessImports = loadFromDisk(_this.FileSystem, outputdirectory, LESS_IMPORTS_FILE);
+    _this.HashCollection = loadFromDisk(_this.FileSystem, outputdirectory, getFileName(this,HASH_FILE_NAME));
+    _this.DebugCollection = loadFromDisk(_this.FileSystem, outputdirectory, getFileName(this,DEBUG_FILE_NAME));
+    _this.LocalizedStrings = loadFromDisk(_this.FileSystem, outputdirectory, getFileName(this,LOCALIZATION_FILE_NAME));
+    _this.AbConfigs = loadFromDisk(_this.FileSystem, outputdirectory, getFileName(this,AB_FILE_NAME));
+    _this.LessImports = loadFromDisk(_this.FileSystem, outputdirectory, getFileName(this,LESS_IMPORTS_FILE));
 };
 
 BundleStatsCollector.prototype.SaveStatsToDisk = function (outputdirectory) {
@@ -106,11 +115,11 @@ BundleStatsCollector.prototype.SaveStatsToDisk = function (outputdirectory) {
             fs.writeFileSync(outputFile, JSON.stringify(data, null, 4))
         };
 
-    saveToDisk(_this.FileSystem, outputdirectory, HASH_FILE_NAME, _this.HashCollection);
-    saveToDisk(_this.FileSystem, outputdirectory, DEBUG_FILE_NAME, _this.DebugCollection);
-    saveToDisk(_this.FileSystem, outputdirectory, LOCALIZATION_FILE_NAME, _this.LocalizedStrings);
-    saveToDisk(_this.FileSystem, outputdirectory, AB_FILE_NAME, _this.AbConfigs);
-    saveToDisk(_this.FileSystem, outputdirectory, LESS_IMPORTS_FILE, _this.LessImports);
+    saveToDisk(_this.FileSystem, outputdirectory, getFileName(this,HASH_FILE_NAME), _this.HashCollection);
+    saveToDisk(_this.FileSystem, outputdirectory, getFileName(this,DEBUG_FILE_NAME), _this.DebugCollection);
+    saveToDisk(_this.FileSystem, outputdirectory, getFileName(this,LOCALIZATION_FILE_NAME), _this.LocalizedStrings);
+    saveToDisk(_this.FileSystem, outputdirectory, getFileName(this,AB_FILE_NAME), _this.AbConfigs);
+    saveToDisk(_this.FileSystem, outputdirectory, getFileName(this,LESS_IMPORTS_FILE), _this.LessImports);
 }
 
 BundleStatsCollector.prototype.AddFileHash = function (bundleName, bundleContents) {

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -71,6 +71,10 @@ if (!bundlerOptions.Directories.length) {
     return;
 }
 
+if(bundlerOptions.DefaultOptions.statsfileprefix) {
+    bundleStatsCollector.setFilePrefix(bundlerOptions.DefaultOptions.statsfileprefix);
+}
+
 if(bundlerOptions.DefaultOptions.rewriteimagefileroot && bundlerOptions.DefaultOptions.rewriteimageoutputroot) {
     imageVersioning = new imageVersioningRequire.BundleImageRewriter(
         fs,

--- a/src/jasmine-tests/bundle-stats/bs-load-from-disk-spec.js
+++ b/src/jasmine-tests/bundle-stats/bs-load-from-disk-spec.js
@@ -4,7 +4,7 @@ var exec = require('child_process').exec,
 
 describe("BundleStatsCollector - Load Hashes From Disk: ", function() {
 
-    var getHasher,
+    var getStatsCollector,
       fileSystem,
       objectOnDisk = { bundle1: "hash1", bundle2: "hash2" },
       outputdirectory = 'folder/folder/2',
@@ -21,54 +21,55 @@ describe("BundleStatsCollector - Load Hashes From Disk: ", function() {
           return JSON.stringify(objectOnDisk);
       };
 
-      getHasher = function () {
+      getStatsCollector = function () {
           spyOn(fileSystem, 'readFileSync').andCallThrough();
           return new bundleStats.BundleStatsCollector(fileSystem);
       };
   });
 
+
   it("Reads the hash file from the correct location.", function() {
-      var hasher = getHasher();
-      hasher.LoadStatsFromDisk(outputdirectory);
+      var stats = getStatsCollector();
+      stats.LoadStatsFromDisk(outputdirectory);
       expect(fileSystem.readFileSync).toHaveBeenCalledWith(expectedHashFile, 'utf8')
   });
 
     it("Reads the debug file from the correct location.", function() {
-        var hasher = getHasher();
-        hasher.LoadStatsFromDisk(outputdirectory);
+        var stats = getStatsCollector();
+        stats.LoadStatsFromDisk(outputdirectory);
         expect(fileSystem.readFileSync).toHaveBeenCalledWith(expectedDebugFile, 'utf8')
     });
 
     it("Reads the localization file from the correct location.", function() {
-        var hasher = getHasher();
-        hasher.LoadStatsFromDisk(outputdirectory);
+        var stats = getStatsCollector();
+        stats.LoadStatsFromDisk(outputdirectory);
         expect(fileSystem.readFileSync).toHaveBeenCalledWith(expectedLocalizationFile, 'utf8')
     });
 
     it("Reads the less imports file from the correct location.", function () {
-        var hasher = getHasher();
-        hasher.LoadStatsFromDisk(outputdirectory);
+        var stats = getStatsCollector();
+        stats.LoadStatsFromDisk(outputdirectory);
         expect(fileSystem.readFileSync).toHaveBeenCalledWith(expectedLessImportFile, 'utf8')
     });
 
     it("Reads the ab config file from the correct location.", function() {
-        var hasher = getHasher();
-        hasher.LoadStatsFromDisk(outputdirectory);
+        var stats = getStatsCollector();
+        stats.LoadStatsFromDisk(outputdirectory);
         expect(fileSystem.readFileSync).toHaveBeenCalledWith(expectedAbConfigFile, 'utf8')
     });
 
   it("Correctly handles trailing slash for input file.", function () {
-      var hasher = getHasher();
-      hasher.LoadStatsFromDisk(outputdirectory + '/');
+      var stats = getStatsCollector();
+      stats.LoadStatsFromDisk(outputdirectory + '/');
       expect(fileSystem.readFileSync).toHaveBeenCalledWith(expectedHashFile, 'utf8')
   });
 
   it("Parses the input file into json.", function () {
-      var hasher = getHasher();
-      hasher.LoadStatsFromDisk(outputdirectory);
+      var stats = getStatsCollector();
+      stats.LoadStatsFromDisk(outputdirectory);
       
-      expect(hasher.HashCollection.bundle1).toBe(objectOnDisk.bundle1);
-      expect(hasher.HashCollection.bundle2).toBe(objectOnDisk.bundle2);
+      expect(stats.HashCollection.bundle1).toBe(objectOnDisk.bundle1);
+      expect(stats.HashCollection.bundle2).toBe(objectOnDisk.bundle2);
   });
 
   it("On file error, the hash collection is empty", function () {
@@ -77,11 +78,54 @@ describe("BundleStatsCollector - Load Hashes From Disk: ", function() {
           throw "an exception";
       };
 
-      var hasher = getHasher();
-      hasher.LoadStatsFromDisk(outputdirectory);
+      var stats = getStatsCollector();
+      stats.LoadStatsFromDisk(outputdirectory);
 
-      expect(hasher.HashCollection.bundle1).toBe(undefined);
-      expect(hasher.HashCollection.bundle2).toBe(undefined);
+      expect(stats.HashCollection.bundle1).toBe(undefined);
+      expect(stats.HashCollection.bundle2).toBe(undefined);
+  });
+
+  describe('given file loading with prefix', function() {
+
+      var prefix = 'a-prefix', stats = null;
+
+      beforeEach(function(){
+
+          stats = getStatsCollector();
+          stats.setFilePrefix(prefix);
+
+          expectedHashFile = outputdirectory + '/' + prefix + bundleStats.HASH_FILE_NAME;
+          expectedDebugFile = outputdirectory + '/' + prefix + bundleStats.DEBUG_FILE_NAME;
+          expectedAbConfigFile = outputdirectory + '/' + prefix + bundleStats.AB_FILE_NAME;
+          expectedLocalizationFile = outputdirectory + '/' + prefix + bundleStats.LOCALIZATION_FILE_NAME;
+          expectedLessImportFile = outputdirectory + '/' + prefix + bundleStats.LESS_IMPORTS_FILE;
+      });
+
+      it("Reads the hash file from the correct location.", function() {
+          stats.LoadStatsFromDisk(outputdirectory);
+          expect(fileSystem.readFileSync).toHaveBeenCalledWith(expectedHashFile, 'utf8')
+      });
+
+      it("Reads the debug file from the correct location.", function() {
+          stats.LoadStatsFromDisk(outputdirectory);
+          expect(fileSystem.readFileSync).toHaveBeenCalledWith(expectedDebugFile, 'utf8')
+      });
+
+      it("Reads the localization file from the correct location.", function() {
+          stats.LoadStatsFromDisk(outputdirectory);
+          expect(fileSystem.readFileSync).toHaveBeenCalledWith(expectedLocalizationFile, 'utf8')
+      });
+
+      it("Reads the less imports file from the correct location.", function () {
+          stats.LoadStatsFromDisk(outputdirectory);
+          expect(fileSystem.readFileSync).toHaveBeenCalledWith(expectedLessImportFile, 'utf8')
+      });
+
+      it("Reads the ab config file from the correct location.", function() {
+          stats.LoadStatsFromDisk(outputdirectory);
+          expect(fileSystem.readFileSync).toHaveBeenCalledWith(expectedAbConfigFile, 'utf8')
+      });
+
   });
 
 });

--- a/src/jasmine-tests/bundle-stats/bs-save-to-disk-spec.js
+++ b/src/jasmine-tests/bundle-stats/bs-save-to-disk-spec.js
@@ -4,7 +4,7 @@ var exec = require('child_process').exec,
 
 describe("BundleStatsCollector - Save Hashes To Disk: ", function() {
 
-    var getHasher,
+    var getStatsCollector,
       fileSystem,
       objectOnDisk = { bundle1: "hash1", bundle2: "hash2" },
       debugOnDisk = { bundle1: [ 'file1'], bundle2: [ 'file2'] },
@@ -28,7 +28,7 @@ describe("BundleStatsCollector - Save Hashes To Disk: ", function() {
       fileSystem = {};
       fileSystem.writeFileSync = function () { };
 
-      getHasher = function () {
+      getStatsCollector = function () {
           spyOn(fileSystem, 'writeFileSync').andCallThrough();
           var hash = new bundleStats.BundleStatsCollector(fileSystem);
           hash.HashCollection = objectOnDisk;
@@ -41,38 +41,38 @@ describe("BundleStatsCollector - Save Hashes To Disk: ", function() {
   });
 
   it("Saves the hash file to the correct location.", function() {
-        var hasher = getHasher();
-        hasher.SaveStatsToDisk(outputdirectory);
+        var stats = getStatsCollector();
+        stats.SaveStatsToDisk(outputdirectory);
         expect(fileSystem.writeFileSync).toHaveBeenCalledWith(expectedHashFile, expectedContents)
     });
 
     it("Saves the debug file to the correct location.", function() {
-        var hasher = getHasher();
-        hasher.SaveStatsToDisk(outputdirectory);
+        var stats = getStatsCollector();
+        stats.SaveStatsToDisk(outputdirectory);
         expect(fileSystem.writeFileSync).toHaveBeenCalledWith(expectedDebugFile, expectedDebugContents)
     });
 
     it("Saves the localization file to the correct location.", function() {
-        var hasher = getHasher();
-        hasher.SaveStatsToDisk(outputdirectory);
+        var stats = getStatsCollector();
+        stats.SaveStatsToDisk(outputdirectory);
         expect(fileSystem.writeFileSync).toHaveBeenCalledWith(expectedLocalizationFile, expectedLocalizationContents)
     });
 
     it("Saves the imports file to the correct location.", function () {
-        var hasher = getHasher();
-        hasher.SaveStatsToDisk(outputdirectory);
+        var stats = getStatsCollector();
+        stats.SaveStatsToDisk(outputdirectory);
         expect(fileSystem.writeFileSync).toHaveBeenCalledWith(expectedLessImportFile, expectedLessImportContents)
     });
 
     it("Saves the ab config file to the correct location.", function() {
-        var hasher = getHasher();
-        hasher.SaveStatsToDisk(outputdirectory);
+        var stats = getStatsCollector();
+        stats.SaveStatsToDisk(outputdirectory);
         expect(fileSystem.writeFileSync).toHaveBeenCalledWith(expectedAbConfigFile, expectedAbConfigContents)
     });
 
   it("Correctly handles trailing slash for output file.", function () {
-      var hasher = getHasher();
-      hasher.SaveStatsToDisk(outputdirectory + '/');
+      var stats = getStatsCollector();
+      stats.SaveStatsToDisk(outputdirectory + '/');
       expect(fileSystem.writeFileSync).toHaveBeenCalledWith(expectedHashFile, expectedContents)
   });
 
@@ -82,14 +82,57 @@ describe("BundleStatsCollector - Save Hashes To Disk: ", function() {
           throw exception;
       };
 
-      var hasher = getHasher();
+      var stats = getStatsCollector();
       try {
-          hasher.SaveStatsToDisk(outputdirectory);
+          stats.SaveStatsToDisk(outputdirectory);
           throw "fail";
       }
       catch(err) {
           expect(err).toBe(exception);
       }
   });
+
+    describe('given file saving with prefix', function() {
+
+        var prefix = 'a-prefix', stats = null;
+
+        beforeEach(function(){
+
+            stats = getStatsCollector();
+            stats.setFilePrefix(prefix);
+
+            expectedHashFile = outputdirectory + '/' + prefix + bundleStats.HASH_FILE_NAME;
+            expectedDebugFile = outputdirectory + '/' + prefix + bundleStats.DEBUG_FILE_NAME;
+            expectedAbConfigFile = outputdirectory + '/' + prefix + bundleStats.AB_FILE_NAME;
+            expectedLocalizationFile = outputdirectory + '/' + prefix + bundleStats.LOCALIZATION_FILE_NAME;
+            expectedLessImportFile = outputdirectory + '/' + prefix + bundleStats.LESS_IMPORTS_FILE;
+        });
+
+        it("Saves the hash file to the correct location.", function() {
+            stats.SaveStatsToDisk(outputdirectory);
+            expect(fileSystem.writeFileSync).toHaveBeenCalledWith(expectedHashFile, expectedContents)
+        });
+
+        it("Saves the debug file to the correct location.", function() {
+            stats.SaveStatsToDisk(outputdirectory);
+            expect(fileSystem.writeFileSync).toHaveBeenCalledWith(expectedDebugFile, expectedDebugContents)
+        });
+
+        it("Saves the localization file to the correct location.", function() {
+            stats.SaveStatsToDisk(outputdirectory);
+            expect(fileSystem.writeFileSync).toHaveBeenCalledWith(expectedLocalizationFile, expectedLocalizationContents)
+        });
+
+        it("Saves the imports file to the correct location.", function () {
+            stats.SaveStatsToDisk(outputdirectory);
+            expect(fileSystem.writeFileSync).toHaveBeenCalledWith(expectedLessImportFile, expectedLessImportContents)
+        });
+
+        it("Saves the ab config file to the correct location.", function() {
+            stats.SaveStatsToDisk(outputdirectory);
+            expect(fileSystem.writeFileSync).toHaveBeenCalledWith(expectedAbConfigFile, expectedAbConfigContents)
+        });
+
+    });
 
 });


### PR DESCRIPTION
@ZocDoc/polaris-devs 

Description
===
Gives an optional prefix for the meta data files that are generated by bundler and consumed by the asset manager.