### PR TITLE
return the filename in the error (and not the useless stack)

### DIFF
--- a/src/bundler.js
+++ b/src/bundler.js
@@ -534,7 +534,7 @@ function getOrCreateJsMustache(options, mustacheText, mPath, jsPath, cb /*cb(js)
 
 function getOrCreateMinJs(options, js, jsPath, minJsPath, cb /*cb(minJs)*/) {
     compileAsync(options, "minifying", function (js, jsPath, cb) {
-        cb(minifyjs(js));
+        cb(minifyjs(js, jsPath));
     }, js, jsPath, minJsPath, cb);
 }
 
@@ -657,12 +657,19 @@ function compileLess(lessCss, lessPath, cb) {
     });
 }
 
-function minifyjs(js) {
-    var ast = jsp.parse(js);
-    ast = pro.ast_mangle(ast);
-    ast = pro.ast_squeeze(ast);
-    var minJs = pro.gen_code(ast);
-    return minJs;
+function minifyjs(js, fileName) {
+    try {
+        var ast = jsp.parse(js);
+        ast = pro.ast_mangle(ast);
+        ast = pro.ast_squeeze(ast);
+        var minJs = pro.gen_code(ast);
+        return minJs;
+    }
+    catch(e) {
+        e.FileName = path.basename(fileName);
+        delete e.stack;
+        throw e;
+    }
 }
 
 function removeCR(text) {


### PR DESCRIPTION
@ZocDoc/polaris-devs @mustafa-rizvi-zocdoc 


Description
===
Mustafa had a js parsing error and bundler returned a useless error.  This adds in the file that broke and removes the useless stack.

From:

![image](https://cloud.githubusercontent.com/assets/2537407/7633062/dd9d1a38-fa1f-11e4-8218-3de178a6b527.png)

To:

![image](https://cloud.githubusercontent.com/assets/2537407/7633053/cc49ae9a-fa1f-11e4-8652-b2f8180957f7.png)
