### PR TITLE
Fix Staging Directory Bug

### DIFF
--- a/src/bundle-file-utility.js
+++ b/src/bundle-file-utility.js
@@ -37,7 +37,7 @@ getStagingDirectory = function(fs, bundleName, filename, options) {
 
     var split = getSplit(bundleName);
     var splitBundle = bundleName.split(split);
-    var outputDir =  options.stagingdirectory + split + splitBundle.pop().replace('.','');
+    var outputDir =  options.stagingdirectory + split + splitBundle.pop().replace(/\./g, "");
 
     var stagingFileName = getStagingFileName(bundleName, filename);
 

--- a/src/jasmine-tests/bundle-file-utility-spec.js
+++ b/src/jasmine-tests/bundle-file-utility-spec.js
@@ -30,6 +30,7 @@ describe("BundleFileUtility - ", function() {
             getOutputFilePath,
             givenOutputDirectory,
             givenStagingDirectory,
+            givenBundleName,
             givenFilePath,
             givenStagingDirectoryExistsForBundle,
             givenStagingDirectoryDoesNotExistForBundle,
@@ -88,7 +89,18 @@ describe("BundleFileUtility - ", function() {
             verifyOutputFilePath('staging-directory\\bundlejs\\file.js');
         });
 
-        it("Staging directory incorprates the director of the file", function() {
+        it("Given bundle name has periods in it, staging directory used for file removes all periods", function() {
+
+            givenBundleName('sg.bundle.js');
+            givenFilePath('file.js');
+            givenStagingDirectory('staging-directory');
+
+            getOutputFilePath();
+
+            verifyOutputFilePath('staging-directory\\sgbundlejs\\file.js');
+        });
+
+        it("Staging directory incorprates the directory of the file", function() {
 
             givenFilePath('folder1/folder2/folder3/file.js');
             givenStagingDirectory('staging-directory');
@@ -123,6 +135,10 @@ describe("BundleFileUtility - ", function() {
 
         givenOutputDirectory = function(directory) {
             _options['outputdirectory'] = directory;
+        };
+
+        givenBundleName = function(name) {
+            bundleName = name;
         };
 
         givenFilePath = function(path) {


### PR DESCRIPTION
@carly-litchfield-zocdoc @jin-hwang-zocdoc @ashley-casey-zocdoc @Andrew-Hagedorn-ZocDoc 

Changes
--
Fixed a bug with the way bundler was generating the staging directory name when the bundle has more than one period in the name. JavaScript's `replace` function only replaces the *first* instance, whereas C# replaces *all* instances, so the name of the folder we were expecting differed from the actual folder we were generating.

**JS**
![image](https://cloud.githubusercontent.com/assets/2537261/8623366/16055ca8-26ff-11e5-99a6-dcbd4e54d2e7.png)
`sg.patient.css` => `sgpatient.css`

**C#**
![image](https://cloud.githubusercontent.com/assets/2537261/8623355/03c9eb80-26ff-11e5-90cf-c61b46d90b8a.png)
`sg.patient.css` => `sgpatientcss`