### PR TITLE
[HUD-1215] Bundler Font URL Rewrite

### DIFF
--- a/src/bundle-image-rewrite.js
+++ b/src/bundle-image-rewrite.js
@@ -39,32 +39,53 @@ function BundleImageRewriter(
         rootPath = rootPath + '/';
     }
 
-    var generateHashOfFile = function (filepath)
-    {
+    var generateHashOfFile = function (filepath) {
         var fileText = fileSystem.readFileSync(filepath);
         return hasher.createHash('md5').update(fileText).digest('hex');
     };
 
     this.rewriteUrl = function (url) {
-        var cleanedUrl = url.replace("url(", "").replace(")", "").replace(/'/g, "").replace(/"/g, "");
-		var filepath = rootPath + cleanedUrl;
+        var cleanedUrl = url.replace("url(", "").replace(/\)/g, "").replace(/'/g, "").replace(/"/g, "");
+
+        var fileUrl;
+        var urlHashMatch = cleanedUrl.match(this.hashRegex);
+        if (urlHashMatch) {
+            fileUrl = urlHashMatch[1];
+        } else {
+            fileUrl = cleanedUrl;
+        }
+
+		var filepath = rootPath + fileUrl;
 		
         var exists = fileSystem.existsSync(filepath);
         if (!exists) {
             return cleanedUrl;
         }
 
-        var hash = generateHashOfFile(filepath);
+        var fileHash = generateHashOfFile(filepath);
         
 		var seperator = '__/';
 		if(cleanedUrl.startsWith('/')) {
 			seperator = '__';
 		}
 		
-        return outputRoot + 'version__' + hash + seperator + cleanedUrl;
-    }
+        return outputRoot + 'version__' + fileHash + seperator + cleanedUrl;
+    };
 
-    this.imageUrlRegex = new RegExp(/url\(.*?[gf]['"]?\)/ig)
+    var fileExtensions = [
+        'eot',
+        'gif',
+        'jpg',
+        'jpeg',
+        'otf',
+        'png',
+        'svg',
+        'ttf',
+        'woff'
+    ];
+
+    this.hashRegex = new RegExp('([^\\?]*)\\??#(.*)');
+    this.urlRegex = new RegExp('url\\([^\\)]*?\\.(?:' + fileExtensions.join('|') + ')(?:\\??#[^\\)]*)?[\'"]?\\)', 'ig');
 }
 
 exports.BundleImageRewriter = BundleImageRewriter;
@@ -73,7 +94,7 @@ exports.BundleImageRewriter = BundleImageRewriter;
 BundleImageRewriter.prototype.VersionImages = function (cssFileText) {
     var _this = this;
 
-    (cssFileText.match(_this.imageUrlRegex) || []).forEach(function (url) {
+    (cssFileText.match(_this.urlRegex) || []).forEach(function (url) {
         var rewrittenUrl = "url('" + _this.rewriteUrl(url) + "')";
         cssFileText = cssFileText.replace(url, rewrittenUrl);
     });

--- a/src/bundle-url-rewrite.js
+++ b/src/bundle-url-rewrite.js
@@ -24,7 +24,7 @@ var ext = require('./string-extensions.js'),
     fs = require("fs"),
     hasher = require('crypto');
 
-function BundleImageRewriter(
+function BundleUrlRewriter(
     fileSystem,
     outputRoot,
     rootPath
@@ -88,10 +88,10 @@ function BundleImageRewriter(
     this.urlRegex = new RegExp('url\\([^\\)]*?\\.(?:' + fileExtensions.join('|') + ')(?:\\??#[^\\)]*)?[\'"]?\\)', 'ig');
 }
 
-exports.BundleImageRewriter = BundleImageRewriter;
+exports.BundleUrlRewriter = BundleUrlRewriter;
 
 
-BundleImageRewriter.prototype.VersionImages = function (cssFileText) {
+BundleUrlRewriter.prototype.VersionUrls = function (cssFileText) {
     var _this = this;
 
     (cssFileText.match(_this.urlRegex) || []).forEach(function (url) {

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -64,12 +64,12 @@ var fs = require("fs"),
     bundleFileUtilityRequire = require('./bundle-file-utility.js'),
     bundleFileUtility,
     bundlerOptions = new optionsRequire.BundlerOptions(),
-    imageVersioningRequire = require('./bundle-image-rewrite.js'),
+    urlRewrite = require('./bundle-url-rewrite.js'),
     ext = require('./string-extensions.js'),
     _ = require('underscore'),
     collection = require('./collection'),
     cssValidator = require('./css-validator'),
-    imageVersioning = null;
+    urlVersioning = null;
 
 bundleFileUtility = new bundleFileUtilityRequire.BundleFileUtility(fs);
 
@@ -90,7 +90,7 @@ if(bundlerOptions.DefaultOptions.statsfileprefix) {
 }
 
 if(bundlerOptions.DefaultOptions.rewriteimagefileroot && bundlerOptions.DefaultOptions.rewriteimageoutputroot) {
-    imageVersioning = new imageVersioningRequire.BundleImageRewriter(
+    urlVersioning = new urlRewrite.BundleUrlRewriter(
         fs,
         bundlerOptions.DefaultOptions.rewriteimageoutputroot,
         bundlerOptions.DefaultOptions.rewriteimagefileroot
@@ -415,8 +415,8 @@ function processCssBundle(options, cssBundle, bundleDir, cssFiles, bundleName, c
 
         var afterBundle = options.skipmin ? cb : function (_) {
 
-            if(imageVersioning) {
-                allMinCss = imageVersioning.VersionImages(allMinCss);
+            if(urlVersioning) {
+                allMinCss = urlVersioning.VersionUrls(allMinCss);
             }
 
             cssValidator.validate(cssBundle, allMinCss, function(err) {

--- a/src/jasmine-tests/bundle-image-rewrite-spec.js
+++ b/src/jasmine-tests/bundle-image-rewrite-spec.js
@@ -4,7 +4,7 @@ var exec = require('child_process').exec,
 
 describe("BundleImageRewriter - ", function () {
 
-    var fileSystem, getImageRewriter, _exists, _filesToText, rootPath, outputRoot, _cssFileText;
+    var fileSystem, getImageRewriter, _exists, _filesToText, rootPath, outputRoot, _cssFileText, _outputFileText;
 
     beforeEach(function () {
 
@@ -30,7 +30,10 @@ describe("BundleImageRewriter - ", function () {
 
     describe("VersionImages: ", function () {
 
-        var fileContents1 = "AN IMAGE FILE 1", fileContents2 = "Something else that is an image too.";;
+        var fileContents1 = "AN IMAGE FILE 1",
+            fileContents2 = "Something else that is an image too.",
+            fileContents3 = "Another file",
+            fileContents4 = "Yet another file";
 
         it("Given an image that doesnt exist, the image is not versioned.", function() {
 
@@ -46,7 +49,7 @@ describe("BundleImageRewriter - ", function () {
 
         it("Given an image that does exist, it reads the image off disk.", function () {
 
-            givenImageFile('img/an-image.jpg', fileContents1);
+            givenFile('img/an-image.jpg', fileContents1);
             givenCssFileText(".s { background: url('img/an-image.jpg') center no-repeat; }");
 
             versionImages();
@@ -56,7 +59,7 @@ describe("BundleImageRewriter - ", function () {
 
         it("Given an image that does exist, it is versioned.", function () {
 
-            givenImageFile('img/an-image.jpg', fileContents1);
+            givenFile('img/an-image.jpg', fileContents1);
             givenCssFileText(".s { background: url('img/an-image.jpg') center no-repeat; }");
 
             versionImages();
@@ -66,7 +69,7 @@ describe("BundleImageRewriter - ", function () {
 		
 		it("Gifs should work.", function () {
 
-			givenImageFile('img/an-image.gif', fileContents1);
+			givenFile('img/an-image.gif', fileContents1);
             givenCssFileText("url(img/an-image.gif) url(img/an-image.gif)");
 
             versionImages();
@@ -76,7 +79,7 @@ describe("BundleImageRewriter - ", function () {
 		
 		it("Pngs should work.", function () {
 
-			givenImageFile('img/an-image.png', fileContents1);
+			givenFile('img/an-image.png', fileContents1);
             givenCssFileText("url(img/an-image.png) url(img/an-image.png)");
 
             versionImages();
@@ -86,7 +89,7 @@ describe("BundleImageRewriter - ", function () {
 			
 		it("Jpgs should work.", function () {
 
-			givenImageFile('img/an-image.jpg', fileContents1);
+			givenFile('img/an-image.jpg', fileContents1);
             givenCssFileText("url(img/an-image.jpg) url(img/an-image.jpg)");
 
             versionImages();
@@ -94,9 +97,75 @@ describe("BundleImageRewriter - ", function () {
             verifyOutputTextIs("url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/img/an-image.jpg') url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/img/an-image.jpg')");
         });
 
+        it('Svgs should work.', function() {
+
+            givenFile('fonts/a-font.svg', fileContents1);
+            givenCssFileText('url(fonts/a-font.svg) url(fonts/a-font.svg)');
+
+            versionImages();
+
+            verifyOutputTextIs("url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font.svg') url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font.svg')");
+
+        });
+
+        it('Ttfs should work.', function() {
+
+            givenFile('fonts/a-font.ttf', fileContents1);
+            givenCssFileText('url(fonts/a-font.ttf) url(fonts/a-font.ttf)');
+
+            versionImages();
+
+            verifyOutputTextIs("url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font.ttf') url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font.ttf')");
+
+        });
+
+        it('Woffs should work.', function() {
+
+            givenFile('fonts/a-font.woff', fileContents1);
+            givenCssFileText('url(fonts/a-font.woff) url(fonts/a-font.woff)');
+
+            versionImages();
+
+            verifyOutputTextIs("url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font.woff') url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font.woff')");
+
+        });
+
+        it('Eots should work.', function() {
+
+            givenFile('fonts/a-font.eot', fileContents1);
+            givenCssFileText('url(fonts/a-font.eot) url(fonts/a-font.eot)');
+
+            versionImages();
+
+            verifyOutputTextIs("url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font.eot') url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font.eot')");
+
+        });
+
+        it('Otfs should work.', function() {
+
+            givenFile('fonts/a-font.otf', fileContents1);
+            givenCssFileText('url(fonts/a-font.otf) url(fonts/a-font.otf)');
+
+            versionImages();
+
+            verifyOutputTextIs("url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font.otf') url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font.otf')");
+
+        });
+
+        it('URLs with hashes are parsed correctly.', function() {
+
+            givenFile('fonts/a-font.otf', fileContents1);
+            givenCssFileText('url(fonts/a-font.otf#foobar)');
+
+            versionImages();
+
+            verifyOutputTextIs("url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font.otf#foobar')");
+
+        });
+
         it("Image urls with double quotes are parsed correctly.", function () {
 
-            givenImageFile('img/an-image.jpg', fileContents1);
+            givenFile('img/an-image.jpg', fileContents1);
             givenCssFileText('.s { background: url("img/an-image.jpg") center no-repeat; }');
 
             versionImages();
@@ -106,7 +175,7 @@ describe("BundleImageRewriter - ", function () {
 
         it("Image urls with no quotes are parsed correctly.", function () {
 
-            givenImageFile('img/another-image.jpg', fileContents1);
+            givenFile('img/another-image.jpg', fileContents1);
             givenCssFileText('.s { background: url(img/another-image.jpg) center no-repeat; }');
 
             versionImages();
@@ -116,7 +185,7 @@ describe("BundleImageRewriter - ", function () {
 
         it("Extra slashes are not added if one already exists.", function () {
 
-            givenImageFile('/img/another-image.jpg', fileContents1);
+            givenFile('/img/another-image.jpg', fileContents1);
             givenCssFileText('.s { background: url(/img/another-image.jpg) center no-repeat; }');
 
             versionImages();
@@ -124,10 +193,46 @@ describe("BundleImageRewriter - ", function () {
             verifyOutputTextIs(".s { background: url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/img/another-image.jpg') center no-repeat; }");
         });
 
+        it('Simple font faces are parsed correctly.', function() {
+
+            givenFile('/fonts/a-font/a-font.eot', fileContents1);
+            givenFile('/fonts/a-font/a-font.woff', fileContents2);
+            givenCssFileText('@font-face{font-family:a-font;src:url(/fonts/a-font/a-font.eot);src:url(/fonts/a-font/a-font.woff);}');
+
+            versionImages();
+
+            verifyOutputTextIs('@font-face{font-family:a-font;src:url(\'combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font/a-font.eot\');src:url(\'combined/version__570e1018fd20af9e8e22c860a43d0ac3__/fonts/a-font/a-font.woff\');}');
+
+        });
+
+        it('Complex font faces are parsed correctly.', function() {
+
+            givenFile('/fonts/a-font/a-font.eot', fileContents1);
+            givenFile('/fonts/a-font/a-font.woff', fileContents2);
+            givenFile('/fonts/a-font/a-font.ttf', fileContents3);
+            givenFile('/fonts/a-font/a-font.svg', fileContents4);
+            givenCssFileText("@font-face{font-family:a-font;src:url(/fonts/a-font/a-font.eot);"
+                + "src:url(/fonts/a-font/a-font.eot?#iefix) format('embedded-opentype'),"
+                + "url(/fonts/a-font/a-font.woff) format('woff'),"
+                + "url(/fonts/a-font/a-font.ttf) format('truetype'),"
+                + "url(/fonts/a-font/a-font.svg#a-font) format('svg');"
+                + "font-weight:400;font-style:normal}");
+
+            versionImages();
+
+            verifyOutputTextIs("@font-face{font-family:a-font;src:url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font/a-font.eot');"
+                + "src:url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font/a-font.eot?#iefix') format('embedded-opentype'),"
+                + "url('combined/version__570e1018fd20af9e8e22c860a43d0ac3__/fonts/a-font/a-font.woff') format('woff'),"
+                + "url('combined/version__74cc7c5a37619838cb7ead3a3450a690__/fonts/a-font/a-font.ttf') format('truetype'),"
+                + "url('combined/version__9887ec636a69b4da275d315709ad8280__/fonts/a-font/a-font.svg#a-font') format('svg');"
+                + "font-weight:400;font-style:normal}");
+
+        });
+
         it("Multiple images in a single file are all versioned.", function () {
 
-            givenImageFile('img/an-image.jpg', fileContents1);
-            givenImageFile('img/another-image.jpg', fileContents2);
+            givenFile('img/an-image.jpg', fileContents1);
+            givenFile('img/another-image.jpg', fileContents2);
             givenCssFileText('.a { background: url(img/another-image.jpg) center no-repeat; }\n'
                             + '.b { background: url("img/an-image.jpg") center no-repeat; }\n'
                             + '.c { background: url("img/another-image.jpg") no-repeat; }\n');
@@ -144,7 +249,7 @@ describe("BundleImageRewriter - ", function () {
             _exists = false;
         };
 
-        var givenImageFile = function (fileName, fileContents) {
+        var givenFile = function (fileName, fileContents) {
             _exists = true;
             _filesToText[rootPath + fileName] = fileContents;
         };

--- a/src/jasmine-tests/bundle-url-rewrite-spec.js
+++ b/src/jasmine-tests/bundle-url-rewrite-spec.js
@@ -1,10 +1,10 @@
 var exec = require('child_process').exec,
     fs = require('fs'),
-    bundleImageRewrite = require('../bundle-image-rewrite.js');
+    bundleUrlRewrite = require('../bundle-url-rewrite.js');
 
-describe("BundleImageRewriter - ", function () {
+describe("BundleUrlRewriter - ", function () {
 
-    var fileSystem, getImageRewriter, _exists, _filesToText, rootPath, outputRoot, _cssFileText, _outputFileText;
+    var fileSystem, getUrlRewriter, _exists, _filesToText, rootPath, outputRoot, _cssFileText, _outputFileText;
 
     beforeEach(function () {
 
@@ -20,15 +20,15 @@ describe("BundleImageRewriter - ", function () {
             return _filesToText[path];
         };
 
-        getImageRewriter = function() {
+        getUrlRewriter = function() {
             spyOn(fileSystem, 'existsSync').andCallThrough();
             spyOn(fileSystem, 'readFileSync').andCallThrough();
-            var util = new bundleImageRewrite.BundleImageRewriter(fileSystem, outputRoot, rootPath);
+            var util = new bundleUrlRewrite.BundleUrlRewriter(fileSystem, outputRoot, rootPath);
             return util;
         };
     });
 
-    describe("VersionImages: ", function () {
+    describe("VersionUrls: ", function () {
 
         var fileContents1 = "AN IMAGE FILE 1",
             fileContents2 = "Something else that is an image too.",
@@ -42,7 +42,7 @@ describe("BundleImageRewriter - ", function () {
             givenImageDoesNotExist();
             givenCssFileText(cssFileText);
 
-            versionImages();
+            versionUrls();
 
             verifyOutputTextIs(cssFileText);
         });
@@ -52,7 +52,7 @@ describe("BundleImageRewriter - ", function () {
             givenFile('img/an-image.jpg', fileContents1);
             givenCssFileText(".s { background: url('img/an-image.jpg') center no-repeat; }");
 
-            versionImages();
+            versionUrls();
 
             expect(fileSystem.readFileSync).toHaveBeenCalledWith(rootPath + "img/an-image.jpg");
         });
@@ -62,7 +62,7 @@ describe("BundleImageRewriter - ", function () {
             givenFile('img/an-image.jpg', fileContents1);
             givenCssFileText(".s { background: url('img/an-image.jpg') center no-repeat; }");
 
-            versionImages();
+            versionUrls();
 
             verifyOutputTextIs(".s { background: url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/img/an-image.jpg') center no-repeat; }");
         });
@@ -72,7 +72,7 @@ describe("BundleImageRewriter - ", function () {
 			givenFile('img/an-image.gif', fileContents1);
             givenCssFileText("url(img/an-image.gif) url(img/an-image.gif)");
 
-            versionImages();
+            versionUrls();
 
             verifyOutputTextIs("url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/img/an-image.gif') url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/img/an-image.gif')");
         });
@@ -82,7 +82,7 @@ describe("BundleImageRewriter - ", function () {
 			givenFile('img/an-image.png', fileContents1);
             givenCssFileText("url(img/an-image.png) url(img/an-image.png)");
 
-            versionImages();
+            versionUrls();
 
             verifyOutputTextIs("url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/img/an-image.png') url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/img/an-image.png')");
         });
@@ -92,7 +92,7 @@ describe("BundleImageRewriter - ", function () {
 			givenFile('img/an-image.jpg', fileContents1);
             givenCssFileText("url(img/an-image.jpg) url(img/an-image.jpg)");
 
-            versionImages();
+            versionUrls();
 
             verifyOutputTextIs("url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/img/an-image.jpg') url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/img/an-image.jpg')");
         });
@@ -102,7 +102,7 @@ describe("BundleImageRewriter - ", function () {
             givenFile('fonts/a-font.svg', fileContents1);
             givenCssFileText('url(fonts/a-font.svg) url(fonts/a-font.svg)');
 
-            versionImages();
+            versionUrls();
 
             verifyOutputTextIs("url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font.svg') url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font.svg')");
 
@@ -113,7 +113,7 @@ describe("BundleImageRewriter - ", function () {
             givenFile('fonts/a-font.ttf', fileContents1);
             givenCssFileText('url(fonts/a-font.ttf) url(fonts/a-font.ttf)');
 
-            versionImages();
+            versionUrls();
 
             verifyOutputTextIs("url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font.ttf') url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font.ttf')");
 
@@ -124,7 +124,7 @@ describe("BundleImageRewriter - ", function () {
             givenFile('fonts/a-font.woff', fileContents1);
             givenCssFileText('url(fonts/a-font.woff) url(fonts/a-font.woff)');
 
-            versionImages();
+            versionUrls();
 
             verifyOutputTextIs("url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font.woff') url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font.woff')");
 
@@ -135,7 +135,7 @@ describe("BundleImageRewriter - ", function () {
             givenFile('fonts/a-font.eot', fileContents1);
             givenCssFileText('url(fonts/a-font.eot) url(fonts/a-font.eot)');
 
-            versionImages();
+            versionUrls();
 
             verifyOutputTextIs("url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font.eot') url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font.eot')");
 
@@ -146,7 +146,7 @@ describe("BundleImageRewriter - ", function () {
             givenFile('fonts/a-font.otf', fileContents1);
             givenCssFileText('url(fonts/a-font.otf) url(fonts/a-font.otf)');
 
-            versionImages();
+            versionUrls();
 
             verifyOutputTextIs("url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font.otf') url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font.otf')");
 
@@ -157,7 +157,7 @@ describe("BundleImageRewriter - ", function () {
             givenFile('fonts/a-font.otf', fileContents1);
             givenCssFileText('url(fonts/a-font.otf#foobar)');
 
-            versionImages();
+            versionUrls();
 
             verifyOutputTextIs("url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font.otf#foobar')");
 
@@ -168,7 +168,7 @@ describe("BundleImageRewriter - ", function () {
             givenFile('img/an-image.jpg', fileContents1);
             givenCssFileText('.s { background: url("img/an-image.jpg") center no-repeat; }');
 
-            versionImages();
+            versionUrls();
 
             verifyOutputTextIs(".s { background: url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/img/an-image.jpg') center no-repeat; }");
         });
@@ -178,7 +178,7 @@ describe("BundleImageRewriter - ", function () {
             givenFile('img/another-image.jpg', fileContents1);
             givenCssFileText('.s { background: url(img/another-image.jpg) center no-repeat; }');
 
-            versionImages();
+            versionUrls();
 
             verifyOutputTextIs(".s { background: url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/img/another-image.jpg') center no-repeat; }");
         });
@@ -188,7 +188,7 @@ describe("BundleImageRewriter - ", function () {
             givenFile('/img/another-image.jpg', fileContents1);
             givenCssFileText('.s { background: url(/img/another-image.jpg) center no-repeat; }');
 
-            versionImages();
+            versionUrls();
 
             verifyOutputTextIs(".s { background: url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/img/another-image.jpg') center no-repeat; }");
         });
@@ -199,7 +199,7 @@ describe("BundleImageRewriter - ", function () {
             givenFile('/fonts/a-font/a-font.woff', fileContents2);
             givenCssFileText('@font-face{font-family:a-font;src:url(/fonts/a-font/a-font.eot);src:url(/fonts/a-font/a-font.woff);}');
 
-            versionImages();
+            versionUrls();
 
             verifyOutputTextIs('@font-face{font-family:a-font;src:url(\'combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font/a-font.eot\');src:url(\'combined/version__570e1018fd20af9e8e22c860a43d0ac3__/fonts/a-font/a-font.woff\');}');
 
@@ -218,7 +218,7 @@ describe("BundleImageRewriter - ", function () {
                 + "url(/fonts/a-font/a-font.svg#a-font) format('svg');"
                 + "font-weight:400;font-style:normal}");
 
-            versionImages();
+            versionUrls();
 
             verifyOutputTextIs("@font-face{font-family:a-font;src:url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font/a-font.eot');"
                 + "src:url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/fonts/a-font/a-font.eot?#iefix') format('embedded-opentype'),"
@@ -237,7 +237,7 @@ describe("BundleImageRewriter - ", function () {
                             + '.b { background: url("img/an-image.jpg") center no-repeat; }\n'
                             + '.c { background: url("img/another-image.jpg") no-repeat; }\n');
 
-            versionImages();
+            versionUrls();
 
             verifyOutputTextIs(".a { background: url('combined/version__570e1018fd20af9e8e22c860a43d0ac3__/img/another-image.jpg') center no-repeat; }\n"
                             + ".b { background: url('combined/version__18458d2016656fdb823ed3ef01b8f8da__/img/an-image.jpg') center no-repeat; }\n"
@@ -258,8 +258,8 @@ describe("BundleImageRewriter - ", function () {
             _cssFileText = text;
         };
      
-        var versionImages = function () {
-            _outputFileText = getImageRewriter().VersionImages(_cssFileText);
+        var versionUrls = function () {
+            _outputFileText = getUrlRewriter().VersionUrls(_cssFileText);
         };
 
         var verifyOutputTextIs = function (expectedFile) {


### PR DESCRIPTION
@ZocDoc/polaris-devs @ashley-casey-zocdoc 

Changes
--
- Fixed some issues with Bundler's CSS URL rewriting that were causing font URLs to be rewritten incorrectly. Now Bundler can properly rewrite both image and font URLs so we can version them.

JIRA Tickets
--
- [**HUD-1215** Bundler incorrectly rewriting font URLs](https://zocdoc.atlassian.net/browse/HUD-1215)