### PR TITLE
Scss Fixes

### DIFF
--- a/src/bundler.js
+++ b/src/bundler.js
@@ -477,8 +477,9 @@ function processCssBundle(options, cssBundle, bundleDir, cssFiles, bundleName, c
                         getOrCreateLessCss(options, lessText, filePath, cssPathOutput, next);
                     });
                 } else if (isSass) {
+                    cssPath = cssPathOutput;
                     readTextFile(filePath, function (sassText) {
-                        getOrCreateSassCss(options, sassText, filePath, cssPath, next);
+                        getOrCreateSassCss(options, sassText, filePath, cssPathOutput, next);
                     });
 				} else if (isStylus){
 					readTextFile(filePath, function (stylusText) {
@@ -561,21 +562,7 @@ function getOrCreateLessCss(options, less, lessPath, cssPath, cb /*cb(css)*/) {
 }
 
 function getOrCreateSassCss(options, sassText, sassPath, cssPath, cb /*cb(sass)*/) {
-    var explodedSassPath = sassPath.split('\\');
-
-    if (explodedSassPath.length == 0) {
-        explodedSassPath = sassPath.split('/');
-    }
-
-    var sassFileName = explodedSassPath.pop();
-    var includePaths = [sassPath.replace(sassFileName, '')];
-
-    compileAsync(options, "compiling", function (sassText, sassPath, cb) {
-        cb(sass.renderSync({
-            file: sassPath,
-            includePaths: includePaths
-        }));
-    }, sassText, sassPath, cssPath, cb);
+    compileAsync(options, "compiling", compileSass, sassText, sassPath, cssPath, cb);
 }
 
 function getOrCreateStylusCss(options, stylusText, stylusPath, cssPath, cb /*cb(css)*/) {
@@ -680,6 +667,28 @@ function compileLess(lessCss, lessPath, cb) {
     less.render(lessCss, options, function (err, css) {
         if (err) handleError(err);
         cb(css.css);
+    });
+}
+
+function compileSass(sassCss, sassPath, cb) {
+    var explodedSassPath = sassPath.split('\\');
+
+    if (explodedSassPath.length == 0) {
+        explodedSassPath = sassPath.split('/');
+    }
+
+    var sassFileName = explodedSassPath.pop();
+    var includePaths = [sassPath.replace(sassFileName, '')];
+
+    sass.render({
+        data: sassCss,
+        includePaths: includePaths,
+        success: function(css) {
+            cb(css);
+        },
+        error: function(err) {
+            handleError(err);
+        }
     });
 }
 

--- a/src/jasmine-tests/bundler-css-spec.js
+++ b/src/jasmine-tests/bundler-css-spec.js
@@ -39,12 +39,25 @@ describe("Css Bundling:", function() {
       runTestCase("combines-less");
   });
 
+  it("Compiles and Concatenates .scss files", function() {
+      runTestCase("combines-scss");
+  });
+
   it("Optionally versions images in the minified file", function () {
       runTestCase("image-versioning-css", null, false, " -rewriteimagefileroot:test-cases/image-versioning-css -rewriteimageoutputroot:combined");
   });
 
   it("An error is thrown for invalid less.", function () {
       var testCase = getTestCase("invalid-less");
+      testCase.VerifyBundle = function () {
+          var hasError = testCase.StdError.indexOf("missing closing `}`") >= 0;
+          expect(hasError).toBe(true);
+      };
+      testCase.RunBundlerAndVerifyOutput();
+  });
+
+  it("An error is thrown for invalid scss.", function () {
+      var testCase = getTestCase("invalid-scss");
       testCase.VerifyBundle = function () {
           var hasError = testCase.StdError.indexOf("missing closing `}`") >= 0;
           expect(hasError).toBe(true);
@@ -88,6 +101,12 @@ describe("Css Bundling:", function() {
   it("If an output directory is specified, then the un-minified less files as .css are put in there..", function () {
       var testCase = getTestCase("output-directory-less", "/folder-output/");
       testCase.SetUpCacheFileTest(true, ["less1.min", "less2.min", "less1", "less2"]);
+      testCase.RunBundlerAndVerifyOutput();
+  });
+
+  it("If an output directory is specified, then the un-minified scss files as .css are put in there..", function () {
+      var testCase = getTestCase("output-directory-scss", "/folder-output/");
+      testCase.SetUpCacheFileTest(true, ["scss1.min", "scss2.min", "scss1", "scss2"]);
       testCase.RunBundlerAndVerifyOutput();
   });
 

--- a/src/jasmine-tests/expected-results/combines-scss/verify.css
+++ b/src/jasmine-tests/expected-results/combines-scss/verify.css
@@ -1,0 +1,2 @@
+#css-results #scss{background:#008000}
+#css-results3 #scss3{background:#000080}

--- a/src/jasmine-tests/test-cases/combines-scss/scss1.scss
+++ b/src/jasmine-tests/test-cases/combines-scss/scss1.scss
@@ -1,0 +1,7 @@
+$green: #008000;
+
+#css-results {
+  #scss {
+    background: $green;
+  }
+}

--- a/src/jasmine-tests/test-cases/combines-scss/scss2.scss
+++ b/src/jasmine-tests/test-cases/combines-scss/scss2.scss
@@ -1,0 +1,7 @@
+$aqua: #088080;
+
+#css-results2 {
+  #scss2 {
+    background: $aqua;
+  }
+}

--- a/src/jasmine-tests/test-cases/combines-scss/scss3.scss
+++ b/src/jasmine-tests/test-cases/combines-scss/scss3.scss
@@ -1,0 +1,7 @@
+$blue: #000080;
+
+#css-results3 {
+  #scss3 {
+    background: $blue;
+  }
+}

--- a/src/jasmine-tests/test-cases/combines-scss/test.css.bundle
+++ b/src/jasmine-tests/test-cases/combines-scss/test.css.bundle
@@ -1,0 +1,2 @@
+scss1.scss
+scss3.scss

--- a/src/jasmine-tests/test-cases/invalid-scss/scss1.scss
+++ b/src/jasmine-tests/test-cases/invalid-scss/scss1.scss
@@ -1,0 +1,2 @@
+$color: red;
+.foo { color: $color;

--- a/src/jasmine-tests/test-cases/invalid-scss/test.css.bundle
+++ b/src/jasmine-tests/test-cases/invalid-scss/test.css.bundle
@@ -1,0 +1,1 @@
+scss1.scss

--- a/src/jasmine-tests/test-cases/output-directory-scss/folder-output/foo.txt
+++ b/src/jasmine-tests/test-cases/output-directory-scss/folder-output/foo.txt
@@ -1,0 +1,1 @@
+This is a dummy file so that git will pull in the directory.

--- a/src/jasmine-tests/test-cases/output-directory-scss/scss1.scss
+++ b/src/jasmine-tests/test-cases/output-directory-scss/scss1.scss
@@ -1,0 +1,7 @@
+$green: #008000;
+
+#css-results {
+  #scss {
+    background: $green;
+  }
+}

--- a/src/jasmine-tests/test-cases/output-directory-scss/scss2.scss
+++ b/src/jasmine-tests/test-cases/output-directory-scss/scss2.scss
@@ -1,0 +1,7 @@
+$blue: #000080;
+
+#css-results2 {
+  #scss2 {
+    background: $blue;
+  }
+}

--- a/src/jasmine-tests/test-cases/output-directory-scss/test.css.bundle
+++ b/src/jasmine-tests/test-cases/output-directory-scss/test.css.bundle
@@ -1,0 +1,4 @@
+#options outputdirectory:test-cases/output-directory-scss/folder-output
+
+scss1.scss
+scss2.scss


### PR DESCRIPTION
@ZocDoc/polaris-devs @ashley-casey-zocdoc @Pam-Hermanto-ZocDoc 

Changes
--
- Bundler was outputting compiled `scss` files in the source directory rather than the staging directory. This updates Bundler to treat `scss` files just like it does `less` files.