### PR TITLE
Source Maps

### DIFF
--- a/ZocDoc.Bundler.nuspec
+++ b/ZocDoc.Bundler.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>ZocDoc-Bundler</id>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <title>ZocDoc - Bundler</title>
     <authors>ZocDoc, Inc.</authors>
     <owners>ZocDoc, Inc.</owners>

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -71,6 +71,7 @@ var fs = require("fs"),
     collection = require('./collection'),
     cssValidator = require('./css-validator'),
     directoryCrawler = require('./directory-crawler'),
+    sourceMap = require('./source-map-utility'),
     urlVersioning = null;
 
 bundleFileUtility = new bundleFileUtilityRequire.BundleFileUtility(fs);
@@ -545,7 +546,16 @@ function getOrCreateJsLiveScript(options, livescriptText, lsPath, jsPath, cb /*c
 
 function getOrCreateJsx(options, jsxText, jsxPath, jsPath, cb) {
     compileAsync(options, "compiling", function(jsxText, jsxPath, cb) {
-            cb(react.transform(jsxText));
+
+            var reactOptions = {};
+
+            if (bundlerOptions.DefaultOptions.sourcemaps) {
+                reactOptions.sourceMap = true;
+                reactOptions.sourceFilename = sourceMap.getSourceFilePath(jsxPath, bundlerOptions.DefaultOptions.siterootdirectory);
+            }
+
+            cb(react.transform(jsxText, reactOptions));
+
         }, jsxText, jsxPath, jsPath, cb);
 }
 

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -690,6 +690,17 @@ function compileLess(lessCss, lessPath, cb) {
             filename: fileName
         };
 
+    if (bundlerOptions.DefaultOptions.sourcemaps) {
+        var directory = path.dirname(lessPath),
+            siteRoot = path.normalize(bundlerOptions.DefaultOptions.siterootdirectory),
+            sourceMapRoot = directory.replace(siteRoot, '');
+
+        options.sourceMap = {
+            sourceMapFileInline: true,
+            sourceMapRootpath: sourceMapRoot
+        };
+    }
+
     if(bundlerOptions.DefaultOptions.outputbundlestats) {
         bundleStatsCollector.SearchForLessImports(lessPath, lessCss);
     }

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -691,13 +691,9 @@ function compileLess(lessCss, lessPath, cb) {
         };
 
     if (bundlerOptions.DefaultOptions.sourcemaps) {
-        var directory = path.dirname(lessPath),
-            siteRoot = path.normalize(bundlerOptions.DefaultOptions.siterootdirectory),
-            sourceMapRoot = directory.replace(siteRoot, '');
-
         options.sourceMap = {
             sourceMapFileInline: true,
-            sourceMapRootpath: sourceMapRoot
+            sourceMapRootpath: sourceMap.getSourceMapRoot(lessPath, bundlerOptions.DefaultOptions.siterootdirectory)
         };
     }
 
@@ -713,17 +709,21 @@ function compileLess(lessCss, lessPath, cb) {
 
 function compileSass(sassCss, sassPath, bundleDir, cb) {
 
-    var includePaths = directoryCrawler.crawl(bundleDir);
-
-    sass.render({
+    var options = {
+        file: path.basename(sassPath),
         data: sassCss,
-        includePaths: includePaths
-    }, function(error, result) {
+        includePaths: directoryCrawler.crawl(bundleDir)
+    };
 
+    if (bundlerOptions.DefaultOptions.sourcemaps) {
+        options.sourceMapRoot = sourceMap.getSourceMapRoot(sassPath, bundlerOptions.DefaultOptions.siterootdirectory);
+        options.sourceMapEmbed = true;
+    }
+
+    sass.render(options, function(error, result) {
         if(error) {
             handleError(error);
-        }
-        else {
+        } else {
             cb(result.css.toString());
         }
     });

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -561,12 +561,19 @@ function getOrCreateJsx(options, jsxText, jsxPath, jsPath, cb) {
 
 function getOrCreateES6(options, es6Text, es6Path, jsPath, cb) {
     compileAsync(options, "compiling", function(es6Text, es6Path, cb) {
-            var result = babel.transform(es6Text, {
-                presets: [
-                    path.join(__dirname, "node_modules", "babel-preset-es2015"),
-                    path.join(__dirname, "node_modules", "babel-preset-react")
-                ]
-            });
+            var babelOptions = {
+                    presets: [
+                        path.join(__dirname, "node_modules", "babel-preset-es2015"),
+                        path.join(__dirname, "node_modules", "babel-preset-react")
+                    ]
+                };
+
+            if (bundlerOptions.DefaultOptions.sourcemaps) {
+                babelOptions.sourceMaps = 'inline';
+                babelOptions.sourceFileName = sourceMap.getSourceFilePath(es6Path, bundlerOptions.DefaultOptions.siterootdirectory);
+            }
+
+            var result = babel.transform(es6Text, babelOptions);
             cb(result.code);
         }, es6Text, es6Path, jsPath, cb);
 }

--- a/src/collection/bundle-file-collection.js
+++ b/src/collection/bundle-file-collection.js
@@ -25,7 +25,10 @@ var resolvePath = function(bundleFile, filePath) {
 BundleFileCollection.prototype.addFile = function(filePath) {
     var absolutePath = resolvePath(this._bundleFile, filePath);
 
-    if (this._bundleType === 'css' && !this._isStyleguideBundle && styleguide.isStyleguideFile(absolutePath)) {
+    if (this._bundleType === 'css'
+        && !this._isStyleguideBundle
+        && styleguide.isStyleguideFile(absolutePath)
+        && !styleguide.isLegacyStyleguideFile(absolutePath)) {
         throw new StyleguideBundleError(this._bundleFile, absolutePath);
     }
 

--- a/src/collection/less-import-collection.js
+++ b/src/collection/less-import-collection.js
@@ -5,7 +5,8 @@ var _ = require('underscore'),
     LessImportError = require('../errors/less-import-error.js');
 
 var isMixinFile = function(filePath) {
-    return filePath.indexOf('mixin') > -1;
+    return filePath.indexOf('mixin') > -1
+        || path.basename(filePath) === 'normalize.less';
 };
 
 var validateStyleguideImports = function(filePath, lessImport) {

--- a/src/directory-crawler.js
+++ b/src/directory-crawler.js
@@ -1,0 +1,40 @@
+var fs = require('fs');
+var path = require('path');
+
+var cache = {};
+
+function crawl(directory) {
+
+    directory = path.resolve(path.normalize(directory));
+
+    if (cache[directory]) {
+        return cache[directory];
+    }
+
+    var directories = [directory];
+
+    var directoryQueue = [directory];
+    while (directoryQueue.length) {
+
+        var currentDirectory = directoryQueue.shift();
+
+        var subDirectories = fs.readdirSync(currentDirectory).map(function(file) {
+            return path.join(currentDirectory, file);
+        }).filter(function(file) {
+            return fs.statSync(file).isDirectory();
+        });
+
+        directories = directories.concat(subDirectories);
+        directoryQueue = directoryQueue.concat(subDirectories);
+
+    }
+
+    cache[directory] = directories;
+
+    return directories;
+
+}
+
+module.exports = {
+    crawl: crawl
+};

--- a/src/source-map-utility.js
+++ b/src/source-map-utility.js
@@ -10,6 +10,16 @@ function getSourceMapRoot(filePath, siteRoot) {
 
 }
 
+function getSourceFilePath(filePath, siteRoot) {
+
+    var sourceMapRoot = getSourceMapRoot(filePath, siteRoot),
+        sourceMapPath = path.join(sourceMapRoot, path.basename(filePath));
+
+    return sourceMapPath.replace(/\\/g, '/')
+
+}
+
 module.exports = {
-    getSourceMapRoot: getSourceMapRoot
+    getSourceMapRoot: getSourceMapRoot,
+    getSourceFilePath: getSourceFilePath
 };

--- a/src/source-map-utility.js
+++ b/src/source-map-utility.js
@@ -1,0 +1,15 @@
+var path = require('path');
+
+function getSourceMapRoot(filePath, siteRoot) {
+
+    var directory = path.dirname(filePath);
+
+    siteRoot = path.normalize(siteRoot);
+
+    return directory.replace(siteRoot, '');
+
+}
+
+module.exports = {
+    getSourceMapRoot: getSourceMapRoot
+};

--- a/src/styleguide/index.js
+++ b/src/styleguide/index.js
@@ -1,16 +1,16 @@
 var path = require('path');
 
 var isExcludedStyleguideFile = function(filePath) {
-    if (filePath.indexOf('legacy') > -1) {
-        return true;
-    }
-
     if (filePath.indexOf('styleguide-documentation') > -1
         || filePath.indexOf('styleguide-docummentation') > -1) {
         return true;
     }
 
     return false;
+};
+
+var isLegacyStyleguideFile = function(filePath) {
+    return filePath.indexOf('legacy') > -1;
 };
 
 var isStyleguideFile = function(filePath) {
@@ -27,5 +27,6 @@ var isStyleguideFile = function(filePath) {
 };
 
 module.exports = {
-    isStyleguideFile: isStyleguideFile
+    isStyleguideFile: isStyleguideFile,
+    isLegacyStyleguideFile: isLegacyStyleguideFile
 };

--- a/tests/integration/source-maps-option-spec.js
+++ b/tests/integration/source-maps-option-spec.js
@@ -1,0 +1,93 @@
+var testDirectory = 'source-maps-option-test-suite';
+var integrationTest = require('./helpers/jasmine-wrapper.js');
+var test = new integrationTest.Test(integrationTest.TestType.Undecided, testDirectory);
+
+test.describeIntegrationTest("Generating source maps:", function() {
+
+    describe("Js files", function () {
+
+        beforeEach(function () {
+            test.resetTestType(integrationTest.TestType.Js);
+        });
+
+        it("Given source maps option and JSX file, then JSX is compiled with inline source maps.", function () {
+
+            test.given.BundleOption('-sourcemaps');
+            test.given.BundleOption('-siterootdirectory:' + test.given.BaseTestDirectory);
+
+            test.given.FileToBundle('file1.jsx',
+                'var file1 = React.createClass({'
+                + '   render: function() {'
+                + '   return <div>file1 {this.props.name}</div>;'
+                + '  }'
+                + '});');
+
+            test.actions.Bundle();
+
+            test.assert.verifyFileAndContentsAre(test.given.TestDirectory, 'file1.js',
+                'var file1 = React.createClass({displayName: "file1",   render: function() {   return React.createElement("div", null, "file1 ", this.props.name);  }});\n'
+              + '//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiL3Rlc3QvZmlsZTEuanN4Iiwic291cmNlcyI6WyIvdGVzdC9maWxlMS5qc3giXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsSUFBSSwyQkFBMkIscUJBQUEsR0FBRyxNQUFNLEVBQUUsV0FBVyxJQUFJLE9BQU8sb0JBQUEsS0FBSSxFQUFBLElBQUMsRUFBQSxRQUFBLEVBQU8sSUFBSSxDQUFDLEtBQUssQ0FBQyxJQUFXLENBQUEsQ0FBQyxHQUFHLENBQUMsQ0FBQyIsInNvdXJjZXNDb250ZW50IjpbInZhciBmaWxlMSA9IFJlYWN0LmNyZWF0ZUNsYXNzKHsgICByZW5kZXI6IGZ1bmN0aW9uKCkgeyAgIHJldHVybiA8ZGl2PmZpbGUxIHt0aGlzLnByb3BzLm5hbWV9PC9kaXY+OyAgfX0pOyJdfQ==');
+
+        });
+
+        it("Given source maps option and ES6 file, then ES6 is compiled with inline source maps.", function () {
+
+            test.given.BundleOption('-sourcemaps');
+            test.given.BundleOption('-siterootdirectory:' + test.given.BaseTestDirectory);
+
+            test.given.FileToBundle('file1.es6',
+                'var odds = evens.map(v => v + 1);');
+
+            test.actions.Bundle();
+
+            test.assert.verifyFileAndContentsAre(test.given.TestDirectory, 'file1.js',
+                '"use strict";\n\n'
+              + 'var odds = evens.map(function (v) {\n'
+              + '  return v + 1;\n'
+              + '});\n'
+              + '//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi90ZXN0L2ZpbGUxLmVzNiJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOztBQUFBLElBQUksSUFBSSxHQUFHLEtBQUssQ0FBQyxHQUFHLENBQUMsVUFBQSxDQUFDO1NBQUksQ0FBQyxHQUFHLENBQUM7Q0FBQSxDQUFDLENBQUMiLCJmaWxlIjoidW5rbm93biIsInNvdXJjZXNDb250ZW50IjpbInZhciBvZGRzID0gZXZlbnMubWFwKHYgPT4gdiArIDEpOyJdfQ==');
+
+        });
+
+    });
+
+    describe("Css Files", function () {
+
+        beforeEach(function () {
+            test.resetTestType(integrationTest.TestType.Css);
+        });
+
+        it("Given source maps option and less file, then less is compiled with inline source maps.", function () {
+
+            test.given.BundleOption('-sourcemaps');
+            test.given.BundleOption('-siterootdirectory:' + test.given.BaseTestDirectory);
+
+            test.given.FileToBundle('less1.less',
+                '@color: red;\n.less1 { color: @color; }');
+
+            test.actions.Bundle();
+
+            test.assert.verifyFileAndContentsAre(test.given.TestDirectory, 'less1.css',
+                ".less1 {\n  color: red;\n}\n/*# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi90ZXN0L2xlc3MxLmxlc3MiXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQ0E7RUFBUyxVQUFBIn0= */");
+
+        });
+
+        it("Given source maps option and scss file, then lscssess is compiled with inline source maps.", function () {
+
+            test.given.BundleOption('-sourcemaps');
+            test.given.BundleOption('-siterootdirectory:' + test.given.BaseTestDirectory);
+
+            test.given.FileToBundle('scss1.scss',
+                '$green: #008000;\n#css-results { #scss { background: $green; } }');
+
+            test.actions.Bundle();
+
+            test.assert.verifyFileAndContentsAre(test.given.TestDirectory, 'scss1.css',
+                "#css-results #scss {\n"
+              + "  background: #008000; }\n\n"
+              + "/*# sourceMappingURL=data:application/json;base64,ewoJInZlcnNpb24iOiAzLAoJInNvdXJjZVJvb3QiOiAiL3Rlc3QiLAoJImZpbGUiOiAic2NzczEuY3NzIiwKCSJzb3VyY2VzIjogWwoJCSJzY3NzMS5zY3NzIgoJXSwKCSJtYXBwaW5ncyI6ICJBQUNBLFlBQVksQ0FBRyxLQUFLLENBQUM7RUFBRSxVQUFVLEVBRHpCLE9BQU8sR0FDOEIiLAoJIm5hbWVzIjogW10KfQ== */");
+
+        });
+
+    });
+});

--- a/tests/unit/collection/bundle-file-collection-spec.js
+++ b/tests/unit/collection/bundle-file-collection-spec.js
@@ -38,6 +38,17 @@ describe('BundleFileCollection', function() {
 
         });
 
+        it('Given non-styleguide css bundle and legacy styleguide file, file is added.', function() {
+
+            givenNonStyleguideBundle('css');
+            givenLegacyStyleguideFile();
+
+            addFile();
+
+            assertFileWasAdded();
+
+        });
+
         it('Given non-styleguide css bundle and non-styleguide file, file is added.', function() {
 
             givenNonStyleguideBundle('css');
@@ -85,6 +96,10 @@ describe('BundleFileCollection', function() {
 
         var givenStyleguideFile = function() {
             file = '../styleguide/foo.less';
+        };
+
+        var givenLegacyStyleguideFile = function() {
+            file = '../styleguide/legacy/foo.less';
         };
 
         var givenNonStyleguideFile = function() {

--- a/tests/unit/collection/less-import-collection-spec.js
+++ b/tests/unit/collection/less-import-collection-spec.js
@@ -122,6 +122,17 @@ describe('LessImportCollection', function() {
 
         });
 
+        it('Given styleguide file imports a styleguide normalize file, import is added.', function() {
+
+            givenStyleguideFile();
+            givenStyleguideNormalizeImport();
+
+            add();
+
+            assertImportWasAddedForFile();
+
+        });
+
         it('Given non-styleguide file imports a styleguide file, error is thrown.', function() {
 
             givenNonStyleguideFile();
@@ -171,6 +182,10 @@ describe('LessImportCollection', function() {
 
         var givenStyleguideMixinImport = function() {
             lessImport = '../../styleguide/foo.mixin.less';
+        };
+
+        var givenStyleguideNormalizeImport = function() {
+            lessImport = '../../styleguide/ui/normalize.less';
         };
 
         var givenNonStyleguideImport = function() {

--- a/tests/unit/source-map-utility-spec.js
+++ b/tests/unit/source-map-utility-spec.js
@@ -1,0 +1,65 @@
+var sourceMap = require('../../src/source-map-utility');
+
+describe('SourceMapUtility', function() {
+
+    var siteRoot = 'C:\\src\\zocdoc.web\\zocdoc_web\\ZocDoc.Web';
+
+    describe('getSourceMapRoot', function() {
+
+        var filePath,
+            root;
+
+        it('Given file, returns file directory relative to site root.', function() {
+        
+            givenFilePathIs(siteRoot + '\\foo\\bar\\baz.js');
+
+            getSourceMapRoot();
+
+            assertRootIs('\\foo\\bar');
+        
+        });
+        
+        var getSourceMapRoot = function() {
+            root = sourceMap.getSourceMapRoot(filePath, siteRoot);
+        };
+
+        var givenFilePathIs = function(file) {
+            filePath = file;
+        };
+
+        var assertRootIs = function(expected) {
+            expect(root).toEqual(expected);
+        };
+
+    });
+
+    describe('getSourceFilePath', function() {
+
+        var filePath,
+            sourceFilePath;
+
+        it('Given file, returns file path relative to site root.', function() {
+
+            givenFilePathIs(siteRoot + '\\foo\\bar\\baz.js');
+
+            getSourceFilePath();
+
+            assertSourceFilePathIs('/foo/bar/baz.js');
+
+        });
+
+        var getSourceFilePath = function() {
+            sourceFilePath = sourceMap.getSourceFilePath(filePath, siteRoot);
+        };
+
+        var givenFilePathIs = function(file) {
+            filePath = file;
+        };
+
+        var assertSourceFilePathIs = function(expected) {
+            expect(sourceFilePath).toEqual(expected);
+        };
+
+    });
+
+});

--- a/tests/unit/styleguide/styleguide-spec.js
+++ b/tests/unit/styleguide/styleguide-spec.js
@@ -37,16 +37,6 @@ describe('Styleguide', function() {
 
         });
 
-        it('Given file name contains styleguide and legacy, returns false.', function() {
-
-            givenFilePathIs('C:/foo/bar/bar.styleguide.legacy.less');
-
-            isStyleguideFile();
-
-            assertFalseWasReturned();
-
-        });
-
         it('Given file name contains styleguide-documentation, returns false.', function() {
 
             givenFilePathIs('C:/foo/styleguide-documentation/bar.less');
@@ -111,6 +101,59 @@ describe('Styleguide', function() {
 
         var assertTrueWasReturned = function() {
             expect(isSgFile).toBeTruthy();
+        };
+
+    });
+
+    describe('isLegacyStyleguideFile', function() {
+
+        var filePath,
+            isLegacyFile;
+
+        it('Given file in legacy styleguide folder, returns true.', function() {
+
+            givenFilePathIs('C:/foo/bar/styleguide/legacy/baz.less');
+
+            isLegacyStyleguideFile();
+
+            assertTrueWasReturned();
+
+        });
+
+        it('Given file with legacy in name, returns true.', function() {
+
+            givenFilePathIs('C:/foo/bar/styleguide/styleguide.legacy.less');
+
+            isLegacyStyleguideFile();
+
+            assertTrueWasReturned();
+
+        });
+
+        it('Given legacy not in file path, returns false.', function() {
+
+            givenFilePathIs('C:/foo/bar/styleguide/styleguide.less');
+
+            isLegacyStyleguideFile();
+
+            assertFalseWasReturned();
+
+        });
+
+        var isLegacyStyleguideFile = function() {
+            isLegacyFile = styleguide.isLegacyStyleguideFile(filePath);
+        };
+
+        var givenFilePathIs = function(path) {
+            filePath = path;
+        };
+
+        var assertFalseWasReturned = function() {
+            expect(isLegacyFile).toBeFalsy();
+        };
+
+        var assertTrueWasReturned = function() {
+            expect(isLegacyFile).toBeTruthy();
         };
 
     });


### PR DESCRIPTION
@ZocDoc/polaris-devs @Pam-Hermanto-ZocDoc @ashley-casey-zocdoc 

Changes
--
Bundler can now optionally include source maps in compiled LESS, SCSS, JSX, and ES6 files. So now, when inspecting elements in the browser, we can link directly to the original line of LESS or SCSS rather than the derived line of CSS. Similarly, we can easily debug JSX and ES6 source code, not the compiled JS.

In the process, I was encountering an issue with our SCSS compiler setup because it couldn't resolve imports properly. So you'll see a bit of code in here related to that.

I will be putting up another small PR to enable source maps when bundling via ZEUS.

Screenshots
--
![image](https://cloud.githubusercontent.com/assets/2537261/11921477/a740b3f6-a757-11e5-9ed4-1ee77f56bd56.png)

![image](https://cloud.githubusercontent.com/assets/2537261/11921478/b18cefb4-a757-11e5-8390-6b21862f9a1f.png)

![image](https://cloud.githubusercontent.com/assets/2537261/11921483/be26608e-a757-11e5-8ba6-cdf0d947233f.png)
