### PR TITLE
Deterministic Uglify

### DIFF
--- a/src/minify/minify-js.js
+++ b/src/minify/minify-js.js
@@ -35,6 +35,8 @@ function minify(options) {
 
 function generateSyntaxTree(js, filePath) {
 
+    uglify.base54.reset();
+
     return uglify.parse(js, {
         filename: filePath
     });

--- a/test-runner/package.json
+++ b/test-runner/package.json
@@ -2,5 +2,6 @@
     "description": "runs the tests in parallel for faster results",
     "dependencies": {
         "async": "~0.8.0"
-    }
+    },
+    "main": "parallel-test-runner.js"
 }

--- a/tests/integration/basic-js-spec.js
+++ b/tests/integration/basic-js-spec.js
@@ -29,7 +29,7 @@ test.describeIntegrationTest("Js Bundling:", function() {
 
         test.assert.verifyBundleIs(
             ';window.JST=window.JST||{},JST.file1=new Hogan.Template({code:function(i,n,a){var e=this;return e.b(a=a||""),e.b("<div> "),e.b(e.v(e.f("a",i,n,0))),e.b(" </div>"),e.fl()},partials:{},subs:{}});\n' +
-            ';window.JST=window.JST||{},JST.file2=new Hogan.Template({code:function(i,n,e){var a=this;return a.b(e=e||""),a.b("<div> "),a.b(a.v(a.f("b",i,n,0))),a.b(" </div>"),a.fl()},partials:{},subs:{}});\n'
+            ';window.JST=window.JST||{},JST.file2=new Hogan.Template({code:function(i,n,b){var e=this;return e.b(b=b||""),e.b("<div> "),e.b(e.v(e.f("b",i,n,0))),e.b(" </div>"),e.fl()},partials:{},subs:{}});\n'
         );
 
     });
@@ -83,7 +83,7 @@ test.describeIntegrationTest("Js Bundling:", function() {
 
         test.assert.verifyBundleIs(
             ';"use strict";var odds=evens.map(function(e){return e+1});\n' +
-            ';"use strict";function _classCallCheck(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}function _possibleConstructorReturn(t,e){if(!t)throw new ReferenceError("this hasn\'t been initialised - super() hasn\'t been called");return!e||"object"!=typeof e&&"function"!=typeof e?t:e}function _inherits(t,e){if("function"!=typeof e&&null!==e)throw new TypeError("Super expression must either be null or a function, not "+typeof e);t.prototype=Object.create(e&&e.prototype,{constructor:{value:t,enumerable:!1,writable:!0,configurable:!0}}),e&&(Object.setPrototypeOf?Object.setPrototypeOf(t,e):t.__proto__=e)}var Foo=function(t){function e(t){_classCallCheck(this,e);var r=_possibleConstructorReturn(this,Object.getPrototypeOf(e).call(this));return r.foo=t,r}return _inherits(e,t),e}(Bar);\n' +
+            ';"use strict";function _classCallCheck(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}function _possibleConstructorReturn(t,e){if(!t)throw new ReferenceError("this hasn\'t been initialised - super() hasn\'t been called");return!e||"object"!=typeof e&&"function"!=typeof e?t:e}function _inherits(t,e){if("function"!=typeof e&&null!==e)throw new TypeError("Super expression must either be null or a function, not "+typeof e);t.prototype=Object.create(e&&e.prototype,{constructor:{value:t,enumerable:!1,writable:!0,configurable:!0}}),e&&(Object.setPrototypeOf?Object.setPrototypeOf(t,e):t.__proto__=e)}var Foo=function(t){function e(t){_classCallCheck(this,e);var o=_possibleConstructorReturn(this,Object.getPrototypeOf(e).call(this));return o.foo=t,o}return _inherits(e,t),e}(Bar);\n' +
             ';"use strict";var name="Bob",time="today",combined="Hello "+name+", how are you "+time+"?";\n'
         );
 
@@ -132,7 +132,7 @@ test.describeIntegrationTest("Js Bundling:", function() {
         test.actions.Bundle();
 
         test.assert.verifyBundleIs(
-            ';window.JST=window.JST||{},JST.file1=new Hogan.Template({code:function(i,e,a){var n=this;return n.b(a=a||""),n.b("<div> "),n.b(n.v(n.f("a",i,e,0))),n.b(" </div>"),n.fl()},partials:{},subs:{}});\n' +
+            ';window.JST=window.JST||{},JST.file1=new Hogan.Template({code:function(i,n,a){var e=this;return e.b(a=a||""),e.b("<div> "),e.b(e.v(e.f("a",i,n,0))),e.b(" </div>"),e.fl()},partials:{},subs:{}});\n' +
             ';var file2="file2";\n' +
             ';var file3=React.createClass({displayName:"file3",render:function(){return React.createElement("div",null,"file3 ",this.props.name)}});\n'
         );

--- a/tests/integration/folder-option-spec.js
+++ b/tests/integration/folder-option-spec.js
@@ -62,7 +62,7 @@ test.describeIntegrationTest("Outputting to another directory:", function() {
             test.assert.verifyBundleIs(
                 ';var file1="file1";\n' +
                 ';var file2="file2";\n' +
-                ';window.JST=window.JST||{},JST.file3=new Hogan.Template({code:function(i,e,f){var l=this;return l.b(f=f||""),l.b("<div> "),l.b(l.v(l.f("c",i,e,0))),l.b(" </div>"),l.fl()},partials:{},subs:{}});\n'
+                ';window.JST=window.JST||{},JST.file3=new Hogan.Template({code:function(i,n,e){var a=this;return a.b(e=e||""),a.b("<div> "),a.b(a.v(a.f("c",i,n,0))),a.b(" </div>"),a.fl()},partials:{},subs:{}});\n'
             );
 
         });

--- a/tests/integration/output-directory-option-spec.js
+++ b/tests/integration/output-directory-option-spec.js
@@ -44,7 +44,7 @@ test.describeIntegrationTest("Outputting to another directory:", function() {
             test.assert.verifyFileAndContentsAre(
                 testDirectory + '/output-dir',
                 'file2.min.js',
-                'window.JST=window.JST||{},JST.file2=new Hogan.Template({code:function(i,e,n){var f=this;return f.b(n=n||""),f.b("<div> "),f.b(f.v(f.f("c",i,e,0))),f.b(" </div>"),f.fl()},partials:{},subs:{}});');
+                'window.JST=window.JST||{},JST.file2=new Hogan.Template({code:function(i,n,e){var a=this;return a.b(e=e||""),a.b("<div> "),a.b(a.v(a.f("c",i,n,0))),a.b(" </div>"),a.fl()},partials:{},subs:{}});');
         });
 
         it("If an output directory is specified, then any computed mustache files are put in it.", function () {

--- a/tests/integration/recompile-spec.js
+++ b/tests/integration/recompile-spec.js
@@ -24,7 +24,7 @@ test.describeIntegrationTest("Recompile Tests - ", function() {
             test.assert.verifyBundleIs(
                 ';var foo="asdf";\n' +
                 ';var foo2="bnmf";\n' +
-                ';window.JST=window.JST||{},JST.mustache1=new Hogan.Template({code:function(a,o,n){var f=this;return f.b(n=n||""),f.b("<div>"),f.b(f.v(f.f("a",a,o,0))),f.b("</div>"),f.fl()},partials:{},subs:{}});\n'
+                ';window.JST=window.JST||{},JST.mustache1=new Hogan.Template({code:function(a,i,n){var e=this;return e.b(n=n||""),e.b("<div>"),e.b(e.v(e.f("a",a,i,0))),e.b("</div>"),e.fl()},partials:{},subs:{}});\n'
             );
 
         });
@@ -38,7 +38,7 @@ test.describeIntegrationTest("Recompile Tests - ", function() {
             test.assert.verifyBundleIs(
                 ';var foo="asdf";\n' +
                 ';var foo2="a new value";\n' +
-                ';window.JST=window.JST||{},JST.mustache1=new Hogan.Template({code:function(a,o,n){var f=this;return f.b(n=n||""),f.b("<div>"),f.b(f.v(f.f("a",a,o,0))),f.b("</div>"),f.fl()},partials:{},subs:{}});\n'
+                ';window.JST=window.JST||{},JST.mustache1=new Hogan.Template({code:function(a,i,n){var e=this;return e.b(n=n||""),e.b("<div>"),e.b(e.v(e.f("a",a,i,0))),e.b("</div>"),e.fl()},partials:{},subs:{}});\n'
             );
 
         });


### PR DESCRIPTION
@ZocDoc/polaris-devs 

Changes
--
- The new version of uglify I updated us to was giving non-deterministic output, so given the same JS input it would minify variables differently from one run to the next. This adds a fix to make it deterministic, so our integration tests can be reliable.