### PR TITLE
Use Babel to Compile React

### DIFF
--- a/src/compile/babel-compiler.js
+++ b/src/compile/babel-compiler.js
@@ -1,0 +1,48 @@
+var babel = require('babel-core');
+var path = require('path');
+var Promise = require('bluebird');
+var sourceMap = require('../source-map-utility');
+
+/**
+ * @param {string[]} presets
+ * @param {object} options
+ * @param {string} options.code
+ * @param {string} options.inputPath
+ * @param {string} options.nodeModulesPath
+ * @param {boolean} options.sourceMap
+ * @param {string} options.siteRoot
+ * @returns {bluebird}
+ */
+function transform(presets, options) {
+
+    return new Promise(function(resolve, reject) {
+
+        try {
+            var babelOptions = {
+                presets: presets.map(function (preset) {
+                    return path.join(options.nodeModulesPath, preset);
+                })
+            };
+
+            if (options.sourceMap) {
+                babelOptions.sourceMaps = 'inline';
+                babelOptions.sourceFileName = sourceMap.getSourceFilePath(options.inputPath, options.siteRoot);
+            }
+
+            var result = babel.transform(options.code, babelOptions);
+
+            resolve(result.code);
+
+        } catch (err) {
+
+            reject(err);
+
+        }
+
+    });
+
+}
+
+module.exports = {
+    transform: transform
+};

--- a/src/compile/compile-es6.js
+++ b/src/compile/compile-es6.js
@@ -1,7 +1,4 @@
-var babel = require('babel-core');
-var path = require('path');
-var Promise = require('bluebird');
-var sourceMap = require('../source-map-utility');
+var babel = require('./babel-compiler');
 
 /**
  * @param {object} options
@@ -14,33 +11,7 @@ var sourceMap = require('../source-map-utility');
  */
 function compile(options) {
 
-    return new Promise(function(resolve, reject) {
-
-        try {
-
-            var babelOptions = {
-                presets: [
-                    path.join(options.nodeModulesPath, 'babel-preset-es2015'),
-                    path.join(options.nodeModulesPath, 'babel-preset-react')
-                ]
-            };
-
-            if (options.sourceMap) {
-                babelOptions.sourceMaps = 'inline';
-                babelOptions.sourceFileName = sourceMap.getSourceFilePath(options.inputPath, options.siteRoot);
-            }
-
-            var result = babel.transform(options.code, babelOptions);
-
-            resolve(result.code);
-
-        } catch (err) {
-
-            reject(err);
-
-        }
-
-    });
+    return babel.transform(['babel-preset-es2015', 'babel-preset-react'], options);
 
 }
 

--- a/src/compile/compile-jsx.js
+++ b/src/compile/compile-jsx.js
@@ -1,39 +1,17 @@
-var Promise = require('bluebird');
-var react = require('react-tools');
-var sourceMap = require('../source-map-utility');
+var babel = require('./babel-compiler');
 
 /**
  * @param {object} options
  * @param {string} options.code
  * @param {string} options.inputPath
+ * @param {string} options.nodeModulesPath
  * @param {boolean} options.sourceMap
  * @param {string} options.siteRoot
  * @returns {bluebird}
  */
 function compile(options) {
 
-    return new Promise(function(resolve, reject) {
-
-        try {
-
-            var reactOptions = {};
-
-            if (options.sourceMap) {
-                reactOptions.sourceMap = true;
-                reactOptions.sourceFilename = sourceMap.getSourceFilePath(options.inputPath, options.siteRoot);
-            }
-
-            var compiledJsx = react.transform(options.code, reactOptions);
-
-            resolve(compiledJsx);
-
-        } catch (err) {
-
-            reject(err);
-
-        }
-
-    });
+    return babel.transform(['babel-preset-react'], options);
 
 }
 

--- a/src/minify/minify-js.js
+++ b/src/minify/minify-js.js
@@ -35,6 +35,8 @@ function minify(options) {
 
 function generateSyntaxTree(js, filePath) {
 
+    uglify.base54.reset();
+
     return uglify.parse(js, {
         filename: filePath
     });

--- a/src/package.json
+++ b/src/package.json
@@ -13,7 +13,6 @@
     "hogan.js-template": "2.0.0",
     "less": "2.5.1",
     "node-sass": "3.4.2",
-    "react-tools": "0.13.1",
     "step": "0.0.5",
     "stylestats": "5.4.3",
     "uglify-js": "^2.6.1",

--- a/test-runner/package.json
+++ b/test-runner/package.json
@@ -2,5 +2,6 @@
     "description": "runs the tests in parallel for faster results",
     "dependencies": {
         "async": "~0.8.0"
-    }
+    },
+    "main": "parallel-test-runner.js"
 }

--- a/tests/integration/basic-js-spec.js
+++ b/tests/integration/basic-js-spec.js
@@ -29,7 +29,7 @@ test.describeIntegrationTest("Js Bundling:", function() {
 
         test.assert.verifyBundleIs(
             ';window.JST=window.JST||{},JST.file1=new Hogan.Template({code:function(i,n,a){var e=this;return e.b(a=a||""),e.b("<div> "),e.b(e.v(e.f("a",i,n,0))),e.b(" </div>"),e.fl()},partials:{},subs:{}});\n' +
-            ';window.JST=window.JST||{},JST.file2=new Hogan.Template({code:function(i,n,e){var a=this;return a.b(e=e||""),a.b("<div> "),a.b(a.v(a.f("b",i,n,0))),a.b(" </div>"),a.fl()},partials:{},subs:{}});\n'
+            ';window.JST=window.JST||{},JST.file2=new Hogan.Template({code:function(i,n,b){var e=this;return e.b(b=b||""),e.b("<div> "),e.b(e.v(e.f("b",i,n,0))),e.b(" </div>"),e.fl()},partials:{},subs:{}});\n'
         );
 
     });
@@ -83,7 +83,7 @@ test.describeIntegrationTest("Js Bundling:", function() {
 
         test.assert.verifyBundleIs(
             ';"use strict";var odds=evens.map(function(e){return e+1});\n' +
-            ';"use strict";function _classCallCheck(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}function _possibleConstructorReturn(t,e){if(!t)throw new ReferenceError("this hasn\'t been initialised - super() hasn\'t been called");return!e||"object"!=typeof e&&"function"!=typeof e?t:e}function _inherits(t,e){if("function"!=typeof e&&null!==e)throw new TypeError("Super expression must either be null or a function, not "+typeof e);t.prototype=Object.create(e&&e.prototype,{constructor:{value:t,enumerable:!1,writable:!0,configurable:!0}}),e&&(Object.setPrototypeOf?Object.setPrototypeOf(t,e):t.__proto__=e)}var Foo=function(t){function e(t){_classCallCheck(this,e);var r=_possibleConstructorReturn(this,Object.getPrototypeOf(e).call(this));return r.foo=t,r}return _inherits(e,t),e}(Bar);\n' +
+            ';"use strict";function _classCallCheck(t,e){if(!(t instanceof e))throw new TypeError("Cannot call a class as a function")}function _possibleConstructorReturn(t,e){if(!t)throw new ReferenceError("this hasn\'t been initialised - super() hasn\'t been called");return!e||"object"!=typeof e&&"function"!=typeof e?t:e}function _inherits(t,e){if("function"!=typeof e&&null!==e)throw new TypeError("Super expression must either be null or a function, not "+typeof e);t.prototype=Object.create(e&&e.prototype,{constructor:{value:t,enumerable:!1,writable:!0,configurable:!0}}),e&&(Object.setPrototypeOf?Object.setPrototypeOf(t,e):t.__proto__=e)}var Foo=function(t){function e(t){_classCallCheck(this,e);var o=_possibleConstructorReturn(this,Object.getPrototypeOf(e).call(this));return o.foo=t,o}return _inherits(e,t),e}(Bar);\n' +
             ';"use strict";var name="Bob",time="today",combined="Hello "+name+", how are you "+time+"?";\n'
         );
 
@@ -132,7 +132,7 @@ test.describeIntegrationTest("Js Bundling:", function() {
         test.actions.Bundle();
 
         test.assert.verifyBundleIs(
-            ';window.JST=window.JST||{},JST.file1=new Hogan.Template({code:function(i,e,a){var n=this;return n.b(a=a||""),n.b("<div> "),n.b(n.v(n.f("a",i,e,0))),n.b(" </div>"),n.fl()},partials:{},subs:{}});\n' +
+            ';window.JST=window.JST||{},JST.file1=new Hogan.Template({code:function(i,n,a){var e=this;return e.b(a=a||""),e.b("<div> "),e.b(e.v(e.f("a",i,n,0))),e.b(" </div>"),e.fl()},partials:{},subs:{}});\n' +
             ';var file2="file2";\n' +
             ';var file3=React.createClass({displayName:"file3",render:function(){return React.createElement("div",null,"file3 ",this.props.name)}});\n'
         );

--- a/tests/integration/folder-option-spec.js
+++ b/tests/integration/folder-option-spec.js
@@ -62,7 +62,7 @@ test.describeIntegrationTest("Outputting to another directory:", function() {
             test.assert.verifyBundleIs(
                 ';var file1="file1";\n' +
                 ';var file2="file2";\n' +
-                ';window.JST=window.JST||{},JST.file3=new Hogan.Template({code:function(i,e,f){var l=this;return l.b(f=f||""),l.b("<div> "),l.b(l.v(l.f("c",i,e,0))),l.b(" </div>"),l.fl()},partials:{},subs:{}});\n'
+                ';window.JST=window.JST||{},JST.file3=new Hogan.Template({code:function(i,n,e){var a=this;return a.b(e=e||""),a.b("<div> "),a.b(a.v(a.f("c",i,n,0))),a.b(" </div>"),a.fl()},partials:{},subs:{}});\n'
             );
 
         });

--- a/tests/integration/output-directory-option-spec.js
+++ b/tests/integration/output-directory-option-spec.js
@@ -75,7 +75,17 @@ test.describeIntegrationTest("Outputting to another directory:", function() {
             test.assert.verifyFileAndContentsAre(
                 testDirectory + '/output-dir',
                 'file2.js',
-                'var file2 = React.createClass({displayName: "file2",   render: function() {   return React.createElement("div", null, "file2 ", this.props.name);  }});');
+                'var file2 = React.createClass({\n' +
+                '  displayName: "file2",\n' +
+                '  render: function () {\n' +
+                '    return React.createElement(\n' +
+                '      "div",\n' +
+                '      null,\n' +
+                '      "file2 ",\n' +
+                '      this.props.name\n' +
+                '    );\n' +
+                '  } });'
+            );
         });
 
         it('If an output directory is specified, then any computed es6 files are put in it.', function() {

--- a/tests/integration/output-directory-option-spec.js
+++ b/tests/integration/output-directory-option-spec.js
@@ -44,7 +44,7 @@ test.describeIntegrationTest("Outputting to another directory:", function() {
             test.assert.verifyFileAndContentsAre(
                 testDirectory + '/output-dir',
                 'file2.min.js',
-                'window.JST=window.JST||{},JST.file2=new Hogan.Template({code:function(i,e,n){var f=this;return f.b(n=n||""),f.b("<div> "),f.b(f.v(f.f("c",i,e,0))),f.b(" </div>"),f.fl()},partials:{},subs:{}});');
+                'window.JST=window.JST||{},JST.file2=new Hogan.Template({code:function(i,n,e){var a=this;return a.b(e=e||""),a.b("<div> "),a.b(a.v(a.f("c",i,n,0))),a.b(" </div>"),a.fl()},partials:{},subs:{}});');
         });
 
         it("If an output directory is specified, then any computed mustache files are put in it.", function () {

--- a/tests/integration/recompile-spec.js
+++ b/tests/integration/recompile-spec.js
@@ -24,7 +24,7 @@ test.describeIntegrationTest("Recompile Tests - ", function() {
             test.assert.verifyBundleIs(
                 ';var foo="asdf";\n' +
                 ';var foo2="bnmf";\n' +
-                ';window.JST=window.JST||{},JST.mustache1=new Hogan.Template({code:function(a,o,n){var f=this;return f.b(n=n||""),f.b("<div>"),f.b(f.v(f.f("a",a,o,0))),f.b("</div>"),f.fl()},partials:{},subs:{}});\n'
+                ';window.JST=window.JST||{},JST.mustache1=new Hogan.Template({code:function(a,i,n){var e=this;return e.b(n=n||""),e.b("<div>"),e.b(e.v(e.f("a",a,i,0))),e.b("</div>"),e.fl()},partials:{},subs:{}});\n'
             );
 
         });
@@ -38,7 +38,7 @@ test.describeIntegrationTest("Recompile Tests - ", function() {
             test.assert.verifyBundleIs(
                 ';var foo="asdf";\n' +
                 ';var foo2="a new value";\n' +
-                ';window.JST=window.JST||{},JST.mustache1=new Hogan.Template({code:function(a,o,n){var f=this;return f.b(n=n||""),f.b("<div>"),f.b(f.v(f.f("a",a,o,0))),f.b("</div>"),f.fl()},partials:{},subs:{}});\n'
+                ';window.JST=window.JST||{},JST.mustache1=new Hogan.Template({code:function(a,i,n){var e=this;return e.b(n=n||""),e.b("<div>"),e.b(e.v(e.f("a",a,i,0))),e.b("</div>"),e.fl()},partials:{},subs:{}});\n'
             );
 
         });

--- a/tests/integration/source-maps-option-spec.js
+++ b/tests/integration/source-maps-option-spec.js
@@ -24,9 +24,21 @@ test.describeIntegrationTest("Generating source maps:", function() {
 
             test.actions.Bundle();
 
-            test.assert.verifyFileAndContentsAre(test.given.TestDirectory, 'file1.js',
-                'var file1 = React.createClass({displayName: "file1",   render: function() {   return React.createElement("div", null, "file1 ", this.props.name);  }});\n'
-              + '//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiL3Rlc3QvZmlsZTEuanN4Iiwic291cmNlcyI6WyIvdGVzdC9maWxlMS5qc3giXSwibmFtZXMiOltdLCJtYXBwaW5ncyI6IkFBQUEsSUFBSSwyQkFBMkIscUJBQUEsR0FBRyxNQUFNLEVBQUUsV0FBVyxJQUFJLE9BQU8sb0JBQUEsS0FBSSxFQUFBLElBQUMsRUFBQSxRQUFBLEVBQU8sSUFBSSxDQUFDLEtBQUssQ0FBQyxJQUFXLENBQUEsQ0FBQyxHQUFHLENBQUMsQ0FBQyIsInNvdXJjZXNDb250ZW50IjpbInZhciBmaWxlMSA9IFJlYWN0LmNyZWF0ZUNsYXNzKHsgICByZW5kZXI6IGZ1bmN0aW9uKCkgeyAgIHJldHVybiA8ZGl2PmZpbGUxIHt0aGlzLnByb3BzLm5hbWV9PC9kaXY+OyAgfX0pOyJdfQ==');
+            test.assert.verifyFileAndContentsAre(
+                test.given.TestDirectory,
+                'file1.js',
+                'var file1 = React.createClass({\n' +
+                '  displayName: "file1",\n' +
+                '  render: function () {\n' +
+                '    return React.createElement(\n' +
+                '      "div",\n' +
+                '      null,\n' +
+                '      "file1 ",\n' +
+                '      this.props.name\n' +
+                '    );\n' +
+                '  } });\n' +
+                '//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIi90ZXN0L2ZpbGUxLmpzeCJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiQUFBQSxJQUFJLEtBQUssR0FBRyxLQUFLLENBQUMsV0FBVyxDQUFDOztBQUFJLFFBQU0sRUFBRSxZQUFXO0FBQUksV0FBTzs7OztNQUFZLElBQUksQ0FBQyxLQUFLLENBQUMsSUFBSTtLQUFPLENBQUM7R0FBRyxFQUFDLENBQUMsQ0FBQyIsImZpbGUiOiJ1bmtub3duIiwic291cmNlc0NvbnRlbnQiOlsidmFyIGZpbGUxID0gUmVhY3QuY3JlYXRlQ2xhc3MoeyAgIHJlbmRlcjogZnVuY3Rpb24oKSB7ICAgcmV0dXJuIDxkaXY+ZmlsZTEge3RoaXMucHJvcHMubmFtZX08L2Rpdj47ICB9fSk7Il19'
+            );
 
         });
 


### PR DESCRIPTION
@ZocDoc/polaris-devs 

Changes
--
- The `react-tools` package we've been using to compile JSX has been deprecated by Facebook. They instead say to use babel to compile JSX files. This updates the `compile-jsx` task to use babel, like we do in `compile-es6`, and removes the `react-tools` package.