### PR TITLE
Mustache Template Update

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "bluebird": "^3.1.5",
     "clean-css": "3.4.4",
     "convert-source-map": "^1.1.3",
+    "handlebars": "^4.0.5",
     "hogan.js-template": "2.0.0",
     "less": "2.5.1",
     "node-sass": "3.4.2",

--- a/src/compile/compile-mustache.js
+++ b/src/compile/compile-mustache.js
@@ -22,7 +22,7 @@ function compile(options) {
             var result = outputTemplate({
                 templateName: templateName,
                 compiledTemplate: compiledTemplate
-            });
+            }).replace(/\r\n/g, '\n');
 
             return {
                 code: result

--- a/src/compile/mustache.hbs
+++ b/src/compile/mustache.hbs
@@ -1,0 +1,26 @@
+(function() {
+
+    var useCommonJs = typeof module !== 'undefined' && module.exports,
+        Hogan,
+        template;
+
+    if (useCommonJs) {
+        Hogan = require('hogan');
+    } else {
+        Hogan = this.Hogan;
+    }
+
+    template = new Hogan.Template({
+        code: {{{compiledTemplate}}},
+        partials: {},
+        subs: {}
+    });
+
+    if (useCommonJs) {
+        module.exports = template;
+    } else {
+        this.JST = this.JST || {};
+        JST['{{{templateName}}}'] = template;
+    }
+
+}).call(this);

--- a/tests/integration/basic-js-spec.js
+++ b/tests/integration/basic-js-spec.js
@@ -28,8 +28,8 @@ test.describeIntegrationTest("Js Bundling:", function() {
         test.actions.Bundle();
 
         test.assert.verifyBundleIs(
-            ';window.JST=window.JST||{},JST.file1=new Hogan.Template({code:function(i,n,a){var e=this;return e.b(a=a||""),e.b("<div> "),e.b(e.v(e.f("a",i,n,0))),e.b(" </div>"),e.fl()},partials:{},subs:{}});\n' +
-            ';window.JST=window.JST||{},JST.file2=new Hogan.Template({code:function(i,n,b){var e=this;return e.b(b=b||""),e.b("<div> "),e.b(e.v(e.f("b",i,n,0))),e.b(" </div>"),e.fl()},partials:{},subs:{}});\n'
+            ';(function(){var e,i,t="undefined"!=typeof module&&module.exports;e=t?require("hogan"):this.Hogan,i=new e.Template({code:function(e,i,t){var o=this;return o.b(t=t||""),o.b("<div> "),o.b(o.v(o.f("a",e,i,0))),o.b(" </div>"),o.fl()},partials:{},subs:{}}),t?module.exports=i:(this.JST=this.JST||{},JST.file1=i)}).call(this);\n' +
+            ';(function(){var e,i,t="undefined"!=typeof module&&module.exports;e=t?require("hogan"):this.Hogan,i=new e.Template({code:function(e,i,t){var o=this;return o.b(t=t||""),o.b("<div> "),o.b(o.v(o.f("b",e,i,0))),o.b(" </div>"),o.fl()},partials:{},subs:{}}),t?module.exports=i:(this.JST=this.JST||{},JST.file2=i)}).call(this);\n'
         );
 
     });
@@ -139,7 +139,7 @@ test.describeIntegrationTest("Js Bundling:", function() {
         test.actions.Bundle();
 
         test.assert.verifyBundleIs(
-            ';window.JST=window.JST||{},JST.file1=new Hogan.Template({code:function(i,n,a){var e=this;return e.b(a=a||""),e.b("<div> "),e.b(e.v(e.f("a",i,n,0))),e.b(" </div>"),e.fl()},partials:{},subs:{}});\n' +
+            ';(function(){var e,i,t="undefined"!=typeof module&&module.exports;e=t?require("hogan"):this.Hogan,i=new e.Template({code:function(e,i,t){var o=this;return o.b(t=t||""),o.b("<div> "),o.b(o.v(o.f("a",e,i,0))),o.b(" </div>"),o.fl()},partials:{},subs:{}}),t?module.exports=i:(this.JST=this.JST||{},JST.file1=i)}).call(this);\n' +
             ';var file2="file2";\n' +
             ';var file3=React.createClass({displayName:"file3",render:function(){return React.createElement("div",null,"file3 ",this.props.name)}});\n'
         );

--- a/tests/integration/folder-option-spec.js
+++ b/tests/integration/folder-option-spec.js
@@ -62,7 +62,7 @@ test.describeIntegrationTest("Outputting to another directory:", function() {
             test.assert.verifyBundleIs(
                 ';var file1="file1";\n' +
                 ';var file2="file2";\n' +
-                ';window.JST=window.JST||{},JST.file3=new Hogan.Template({code:function(i,n,e){var a=this;return a.b(e=e||""),a.b("<div> "),a.b(a.v(a.f("c",i,n,0))),a.b(" </div>"),a.fl()},partials:{},subs:{}});\n'
+                ';(function(){vare,i,t="undefined"!=typeofmodule&&module.exports;e=t?require("hogan"):this.Hogan,i=newe.Template({code:function(e,i,t){varo=this;returno.b(t=t||""),o.b("<div>"),o.b(o.v(o.f("c",e,i,0))),o.b("</div>"),o.fl()},partials:{},subs:{}}),t?module.exports=i:(this.JST=this.JST||{},JST.file3=i)}).call(this);\n'
             );
 
         });

--- a/tests/integration/folder-option-spec.js
+++ b/tests/integration/folder-option-spec.js
@@ -62,7 +62,7 @@ test.describeIntegrationTest("Outputting to another directory:", function() {
             test.assert.verifyBundleIs(
                 ';var file1="file1";\n' +
                 ';var file2="file2";\n' +
-                ';(function(){vare,i,t="undefined"!=typeofmodule&&module.exports;e=t?require("hogan"):this.Hogan,i=newe.Template({code:function(e,i,t){varo=this;returno.b(t=t||""),o.b("<div>"),o.b(o.v(o.f("c",e,i,0))),o.b("</div>"),o.fl()},partials:{},subs:{}}),t?module.exports=i:(this.JST=this.JST||{},JST.file3=i)}).call(this);\n'
+                ';(function(){var e,i,t="undefined"!=typeof module&&module.exports;e=t?require("hogan"):this.Hogan,i=new e.Template({code:function(e,i,t){var o=this;return o.b(t=t||""),o.b("<div> "),o.b(o.v(o.f("c",e,i,0))),o.b(" </div>"),o.fl()},partials:{},subs:{}}),t?module.exports=i:(this.JST=this.JST||{},JST.file3=i)}).call(this);\n'
             );
 
         });

--- a/tests/integration/helpers/integration-test-helper.js
+++ b/tests/integration/helpers/integration-test-helper.js
@@ -136,7 +136,17 @@ TestUtility.prototype.VerifyFileContents = function (dir, fileName, expectedCont
     var _this = this;
     _this.runFunc(function () {
         var bundleContents = _this.FileSystem.readFileSync(dir + '/' + fileName, 'utf8');
-        expect(bundleContents.replace(/\s/g, '')).toBe(expectedContents.replace(/\s/g, ''));
+        if (expectedContents.length !== bundleContents.length) {
+            _this.Console.log('Expected string of length ' + expectedContents.length + ', but actually was string of length ' + bundleContents.length);
+        }
+        for (var i = 0; i < bundleContents.length && i < expectedContents.length; i++) {
+            if (bundleContents[i] !== expectedContents[i]) {
+                _this.Console.log('Mismatch at character ' + i + ': expected ' + JSON.stringify(expectedContents[i]) + ', but was ' + JSON.stringify(bundleContents[i]));
+                _this.Console.log('Expected: ' + JSON.stringify(expectedContents.substr(0, i) + ', actual: ' + JSON.stringify(bundleContents.substr(0, i))));
+                break;
+            }
+        }
+        expect(bundleContents).toBe(expectedContents);
     });
 }
 

--- a/tests/integration/helpers/integration-test-helper.js
+++ b/tests/integration/helpers/integration-test-helper.js
@@ -136,7 +136,7 @@ TestUtility.prototype.VerifyFileContents = function (dir, fileName, expectedCont
     var _this = this;
     _this.runFunc(function () {
         var bundleContents = _this.FileSystem.readFileSync(dir + '/' + fileName, 'utf8');
-        expect(bundleContents).toBe(expectedContents);
+        expect(bundleContents.replace(/\s/g, '')).toBe(expectedContents.replace(/\s/g, ''));
     });
 }
 

--- a/tests/integration/output-directory-option-spec.js
+++ b/tests/integration/output-directory-option-spec.js
@@ -44,7 +44,7 @@ test.describeIntegrationTest("Outputting to another directory:", function() {
             test.assert.verifyFileAndContentsAre(
                 testDirectory + '/output-dir',
                 'file2.min.js',
-                'window.JST=window.JST||{},JST.file2=new Hogan.Template({code:function(i,n,e){var a=this;return a.b(e=e||""),a.b("<div> "),a.b(a.v(a.f("c",i,n,0))),a.b(" </div>"),a.fl()},partials:{},subs:{}});');
+                '(function(){var e,i,t="undefined"!=typeof module&&module.exports;e=t?require("hogan"):this.Hogan,i=new e.Template({code:function(e,i,t){var o=this;return o.b(t=t||""),o.b("<div> "),o.b(o.v(o.f("c",e,i,0))),o.b(" </div>"),o.fl()},partials:{},subs:{}}),t?module.exports=i:(this.JST=this.JST||{},JST.file2=i)}).call(this);');
         });
 
         it("If an output directory is specified, then any computed mustache files are put in it.", function () {
@@ -57,7 +57,33 @@ test.describeIntegrationTest("Outputting to another directory:", function() {
             test.assert.verifyFileAndContentsAre(
                 testDirectory + '/output-dir',
                 'file2.js',
-                'window["JST"] = window["JST"] || {}; JST[\'file2\'] = new Hogan.Template({ code: function(c,p,i){var _=this;_.b(i=i||"");_.b("<div> ");_.b(_.v(_.f("c",c,p,0)));_.b(" </div>");return _.fl();;}, partials: {}, subs: {} });');
+                '(function() {\n' +
+                '\n' +
+                '    var useCommonJs = typeof module !== \'undefined\' && module.exports,\n' +
+                '        Hogan,\n' +
+                '        template;\n' +
+                '\n' +
+                '    if (useCommonJs) {\n' +
+                '        Hogan = require(\'hogan\');\n' +
+                '    } else {\n' +
+                '        Hogan = this.Hogan;\n' +
+                '    }\n' +
+                '\n' +
+                '    template = new Hogan.Template({\n' +
+                '        code: function(c,p,i){var _=this;_.b(i=i||"");_.b("<div> ");_.b(_.v(_.f("c",c,p,0)));_.b(" </div>");return _.fl();;},\n' +
+                '        partials: {},\n' +
+                '        subs: {}\n' +
+                '    });\n' +
+                '\n' +
+                '    if (useCommonJs) {\n' +
+                '        module.exports = template;\n' +
+                '    } else {\n' +
+                '        this.JST = this.JST || {};\n' +
+                '        JST[\'file2\'] = template;\n' +
+                '    }\n' +
+                '\n' +
+                '}).call(this);'
+            );
         });
 
         it("If an output directory is specified, then any computed jsx files are put in it.", function () {

--- a/tests/integration/recompile-spec.js
+++ b/tests/integration/recompile-spec.js
@@ -24,7 +24,7 @@ test.describeIntegrationTest("Recompile Tests - ", function() {
             test.assert.verifyBundleIs(
                 ';var foo="asdf";\n' +
                 ';var foo2="bnmf";\n' +
-                ';window.JST=window.JST||{},JST.mustache1=new Hogan.Template({code:function(a,i,n){var e=this;return e.b(n=n||""),e.b("<div>"),e.b(e.v(e.f("a",a,i,0))),e.b("</div>"),e.fl()},partials:{},subs:{}});\n'
+                ';(function(){vare,t,i="undefined"!=typeofmodule&&module.exports;e=i?require("hogan"):this.Hogan,t=newe.Template({code:function(e,t,i){varo=this;returno.b(i=i||""),o.b("<div>"),o.b(o.v(o.f("a",e,t,0))),o.b("</div>"),o.fl()},partials:{},subs:{}}),i?module.exports=t:(this.JST=this.JST||{},JST.mustache1=t)}).call(this);\n'
             );
 
         });
@@ -38,7 +38,7 @@ test.describeIntegrationTest("Recompile Tests - ", function() {
             test.assert.verifyBundleIs(
                 ';var foo="asdf";\n' +
                 ';var foo2="a new value";\n' +
-                ';window.JST=window.JST||{},JST.mustache1=new Hogan.Template({code:function(a,i,n){var e=this;return e.b(n=n||""),e.b("<div>"),e.b(e.v(e.f("a",a,i,0))),e.b("</div>"),e.fl()},partials:{},subs:{}});\n'
+                ';(function(){vare,t,i="undefined"!=typeofmodule&&module.exports;e=i?require("hogan"):this.Hogan,t=newe.Template({code:function(e,t,i){varo=this;returno.b(i=i||""),o.b("<div>"),o.b(o.v(o.f("a",e,t,0))),o.b("</div>"),o.fl()},partials:{},subs:{}}),i?module.exports=t:(this.JST=this.JST||{},JST.mustache1=t)}).call(this);\n'
             );
 
         });
@@ -52,7 +52,7 @@ test.describeIntegrationTest("Recompile Tests - ", function() {
             test.assert.verifyBundleIs(
                 ';var foo="asdf";\n' +
                 ';var foo2="bnmf";\n' +
-                ';window.JST=window.JST||{},JST.mustache1=new Hogan.Template({code:function(a,n,b){var e=this;return e.b(b=b||""),e.b("<a>"),e.b(e.v(e.f("b",a,n,0))),e.b("</a>"),e.fl()},partials:{},subs:{}});\n'
+                ';(function(){vare,t,a="undefined"!=typeofmodule&&module.exports;e=a?require("hogan"):this.Hogan,t=newe.Template({code:function(e,t,a){varo=this;returno.b(a=a||""),o.b("<a>"),o.b(o.v(o.f("b",e,t,0))),o.b("</a>"),o.fl()},partials:{},subs:{}}),a?module.exports=t:(this.JST=this.JST||{},JST.mustache1=t)}).call(this);\n'
             );
 
         });

--- a/tests/integration/recompile-spec.js
+++ b/tests/integration/recompile-spec.js
@@ -24,7 +24,7 @@ test.describeIntegrationTest("Recompile Tests - ", function() {
             test.assert.verifyBundleIs(
                 ';var foo="asdf";\n' +
                 ';var foo2="bnmf";\n' +
-                ';(function(){vare,t,i="undefined"!=typeofmodule&&module.exports;e=i?require("hogan"):this.Hogan,t=newe.Template({code:function(e,t,i){varo=this;returno.b(i=i||""),o.b("<div>"),o.b(o.v(o.f("a",e,t,0))),o.b("</div>"),o.fl()},partials:{},subs:{}}),i?module.exports=t:(this.JST=this.JST||{},JST.mustache1=t)}).call(this);\n'
+                ';(function(){var e,t,i="undefined"!=typeof module&&module.exports;e=i?require("hogan"):this.Hogan,t=new e.Template({code:function(e,t,i){var o=this;return o.b(i=i||""),o.b("<div>"),o.b(o.v(o.f("a",e,t,0))),o.b("</div>"),o.fl()},partials:{},subs:{}}),i?module.exports=t:(this.JST=this.JST||{},JST.mustache1=t)}).call(this);\n'
             );
 
         });
@@ -38,7 +38,7 @@ test.describeIntegrationTest("Recompile Tests - ", function() {
             test.assert.verifyBundleIs(
                 ';var foo="asdf";\n' +
                 ';var foo2="a new value";\n' +
-                ';(function(){vare,t,i="undefined"!=typeofmodule&&module.exports;e=i?require("hogan"):this.Hogan,t=newe.Template({code:function(e,t,i){varo=this;returno.b(i=i||""),o.b("<div>"),o.b(o.v(o.f("a",e,t,0))),o.b("</div>"),o.fl()},partials:{},subs:{}}),i?module.exports=t:(this.JST=this.JST||{},JST.mustache1=t)}).call(this);\n'
+                ';(function(){var e,t,i="undefined"!=typeof module&&module.exports;e=i?require("hogan"):this.Hogan,t=new e.Template({code:function(e,t,i){var o=this;return o.b(i=i||""),o.b("<div>"),o.b(o.v(o.f("a",e,t,0))),o.b("</div>"),o.fl()},partials:{},subs:{}}),i?module.exports=t:(this.JST=this.JST||{},JST.mustache1=t)}).call(this);\n'
             );
 
         });
@@ -52,7 +52,7 @@ test.describeIntegrationTest("Recompile Tests - ", function() {
             test.assert.verifyBundleIs(
                 ';var foo="asdf";\n' +
                 ';var foo2="bnmf";\n' +
-                ';(function(){vare,t,a="undefined"!=typeofmodule&&module.exports;e=a?require("hogan"):this.Hogan,t=newe.Template({code:function(e,t,a){varo=this;returno.b(a=a||""),o.b("<a>"),o.b(o.v(o.f("b",e,t,0))),o.b("</a>"),o.fl()},partials:{},subs:{}}),a?module.exports=t:(this.JST=this.JST||{},JST.mustache1=t)}).call(this);\n'
+                ';(function(){var e,t,a="undefined"!=typeof module&&module.exports;e=a?require("hogan"):this.Hogan,t=new e.Template({code:function(e,t,a){var o=this;return o.b(a=a||""),o.b("<a>"),o.b(o.v(o.f("b",e,t,0))),o.b("</a>"),o.fl()},partials:{},subs:{}}),a?module.exports=t:(this.JST=this.JST||{},JST.mustache1=t)}).call(this);\n'
             );
 
         });


### PR DESCRIPTION
@ZocDoc/polaris-devs @Dillen-Roggensinger-ZocDoc 

Changes
--
- The way we currently compile our mustache templates explicitly attaches them to `window.JST`. That's going to cause issues when we try to namespace all our JS code for syndication. This updates the way we format our compiled mustache templates so that they attach to `this`, not `window`. While I was there, I also made them `require`/`module.exports` friendly.