### PR TITLE
Promisify Concat

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "bundler",
   "version": "1.0.9",
+  "license": "SEE LICENSE IN LICENSE",
   "repository": {
     "type": "git",
     "url": "https://github.com/ZocDoc/Bundler"

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -328,7 +328,17 @@ function processJsBundle(options, jsBundle, bundleDir, jsFiles, bundleName, cb) 
 
                 readTextFile(filePath, function(code) {
 
-                    var compileOptions = getProcessCodeOptions(code, undefined, filePath, jsPathOutput, bundleDir, bundleStatsCollector, options);
+                    var compileOptions = {
+                        code: code,
+                        originalPath: filePath,
+                        inputPath: filePath,
+                        outputPath: jsPathOutput,
+                        bundleDir: bundleDir,
+                        bundleStatsCollector: bundleStatsCollector,
+                        sourceMap: options.sourcemaps,
+                        siteRoot: options.siterootdirectory,
+                        useTemplateDirs: options.usetemplatedirs
+                    };
 
                     if (isMustache) {
 
@@ -349,8 +359,9 @@ function processJsBundle(options, jsBundle, bundleDir, jsFiles, bundleName, cb) 
 
                         bundleStatsCollector.ParseJsForStats(jsBundle, code);
                         next({
+                            code: code,
                             path: jsPath,
-                            code: code
+                            originalPath: filePath
                         });
 
                     }
@@ -367,8 +378,18 @@ function processJsBundle(options, jsBundle, bundleDir, jsFiles, bundleName, cb) 
                     if (! --pending) whenDone();
                 };
 
-                var minifyOptions = getProcessCodeOptions(js.code, js.map, jsPath, minJsPath, bundleDir, bundleStatsCollector, options);
-                minify.js(minifyOptions).then(withMin).catch(handleError);
+                minify.js({
+                    code: js.code,
+                    map: js.map,
+                    originalPath: filePath,
+                    inputPath: jsPath,
+                    outputPath: minJsPath,
+                    bundleDir: bundleDir,
+                    bundleStatsCollector: bundleStatsCollector,
+                    sourceMap: options.sourcemaps,
+                    siteRoot: options.siterootdirectory,
+                    useTemplateDirs: options.usetemplatedirs
+                }).then(withMin).catch(handleError);
             }
         );
     });
@@ -464,7 +485,17 @@ function processCssBundle(options, cssBundle, bundleDir, cssFiles, bundleName, c
 
                 readTextFile(filePath, function(code) {
 
-                    var compileOptions = getProcessCodeOptions(code, undefined, filePath, cssPathOutput, bundleDir, bundleStatsCollector, options);
+                    var compileOptions = {
+                        code: code,
+                        originalPath: filePath,
+                        inputPath: filePath,
+                        outputPath: cssPathOutput,
+                        bundleDir: bundleDir,
+                        bundleStatsCollector: bundleStatsCollector,
+                        sourceMap: options.sourcemaps,
+                        siteRoot: options.siterootdirectory,
+                        useTemplateDirs: options.usetemplatedirs
+                    };
 
                     if (isLess) {
 
@@ -477,8 +508,9 @@ function processCssBundle(options, cssBundle, bundleDir, cssFiles, bundleName, c
                     } else {
 
                         next({
+                            code: code,
                             path: cssPath,
-                            code: code
+                            originalPath: filePath
                         });
 
                     }
@@ -494,27 +526,21 @@ function processCssBundle(options, cssBundle, bundleDir, cssFiles, bundleName, c
                     if (! --pending) whenDone();
                 };
 
-                var minifyOptions = getProcessCodeOptions(css.code, css.map, cssPath, minCssPath, bundleDir, bundleStatsCollector, options);
-                minify.css(minifyOptions).then(withMin).catch(handleError);
+                minify.css({
+                    code: css.code,
+                    map: css.map,
+                    originalPath: filePath,
+                    inputPath: cssPath,
+                    outputPath: minCssPath,
+                    bundleDir: bundleDir,
+                    bundleStatsCollector: bundleStatsCollector,
+                    sourceMap: options.sourcemaps,
+                    siteRoot: options.siterootdirectory,
+                    useTemplateDirs: options.usetemplatedirs
+                }).then(withMin).catch(handleError);
             }
         );
     });
-}
-
-function getProcessCodeOptions(code, map, inputPath, outputPath, bundleDir, bundleStatsCollector, bundlerOptions) {
-
-    return {
-        code: code,
-        map: map,
-        inputPath: inputPath,
-        outputPath: outputPath,
-        bundleDir: bundleDir,
-        bundleStatsCollector: bundleStatsCollector,
-        sourceMap: bundlerOptions.sourcemaps,
-        siteRoot: bundlerOptions.siterootdirectory,
-        useTemplateDirs: bundlerOptions.usetemplatedirs
-    };
-
 }
 
 function removeCR(text) {

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -374,47 +374,51 @@ function processCssBundle(options, cssBundle, bundleDir, cssFiles, bundleName, c
 
     var allCssArr = [], allMinCssArr = [], index = 0, pending = 0;
     var whenDone = function () {
-        var allCss = concat.files({
-                files: allCssArr,
-                fileType: file.type.CSS,
-                sourceMap: options.sourcemaps
-            }),
-            allMinCss = concat.files({
-                files: allMinCssArr,
-                fileType: file.type.CSS,
-                sourceMap: options.sourcemaps
-            });
-
-        var afterBundle = function () {
-
-            if(urlVersioning) {
-                allMinCss.code = urlVersioning.VersionUrls(allMinCss.code);
-            }
-
-            cssValidator.validate(cssBundle, allMinCss.code, function(err) {
-                if (err) {
-                    handleError(err);
-                    return;
-                }
-
-                var minFileName = bundleFileUtility.getMinFileName(bundleName, bundleName, options);
-
-                file.write(allMinCss.code, allMinCss.map, file.type.CSS, minFileName, options.siterootdirectory)
-                    .then(cb)
-                    .catch(handleError);
-
-            });
-        };
-
-        bundleStatsCollector.AddFileHash(bundleName, allMinCss.code);
-
-        file.write(allCss.code, allCss.map, file.type.CSS, bundleName, options.siterootdirectory)
-            .then(afterBundle)
-            .catch(handleError);
 
         allCssArr.forEach(function(cssFile) {
             bundleStatsCollector.AddDebugFile(cssBundle, cssFile.path);
         });
+
+        concat.files({
+                files: allCssArr,
+                fileType: file.type.CSS,
+                sourceMap: options.sourcemaps
+            })
+            .then(function(allCss) {
+
+                return file.write(allCss.code, allCss.map, file.type.CSS, bundleName, options.siterootdirectory);
+
+            })
+            .then(function() {
+
+                return concat.files({
+                    files: allMinCssArr,
+                    fileType: file.type.CSS,
+                    sourceMap: options.sourcemaps
+                });
+
+            })
+            .then(function(allMinCss) {
+
+                if (urlVersioning) {
+                    allMinCss.code = urlVersioning.VersionUrls(allMinCss.code);
+                }
+
+                return cssValidator.validate(cssBundle, allMinCss);
+
+            })
+            .then(function(allMinCss) {
+
+                bundleStatsCollector.AddFileHash(bundleName, allMinCss.code);
+
+                var minFileName = bundleFileUtility.getMinFileName(bundleName, bundleName, options);
+
+                return file.write(allMinCss.code, allMinCss.map, file.type.CSS, minFileName, options.siterootdirectory);
+
+            })
+            .then(cb)
+            .catch(handleError);
+
     };
 
     bundleStatsCollector.ClearStatsForBundle(cssBundle);

--- a/src/concat/concat-files.js
+++ b/src/concat/concat-files.js
@@ -1,59 +1,66 @@
 var FileType = require('../file').type;
 var Combiner = require('./source-map-combiner');
+var requireify = require('./requireify');
+var Promise = require('bluebird');
 
 /**
  * @param {object} options
  * @param {Array<object>} options.files
  * @param {string} options.fileType
  * @param {boolean} options.sourceMap
+ * @returns {Promise}
  */
 function concat(options) {
 
-    var code = [],
-        offset,
-        combiner,
-        result;
+    return new Promise(function(resolve) {
 
-    if (options.sourceMap) {
-        offset = 0;
-        combiner = new Combiner();
-    }
-
-    options.files.forEach(function(file) {
-
-        switch (options.fileType) {
-
-            case FileType.CSS:
-                code.push(file.code);
-                code.push('\n');
-                break;
-
-            case FileType.JS:
-                code.push(';');
-                code.push(file.code);
-                code.push('\n');
-                break;
-
-        }
+        var code = [],
+            result,
+            offset,
+            combiner;
 
         if (options.sourceMap) {
-            combiner.addFile(file.path, file.code, file.map, {
-                line: offset
-            });
-            offset += newlinesIn(file.code) + 1;
+            offset = 0;
+            combiner = new Combiner();
         }
 
+        options.files.forEach(function(file) {
+
+            switch (options.fileType) {
+
+                case FileType.CSS:
+                    code.push(file.code);
+                    code.push('\n');
+                    break;
+
+                case FileType.JS:
+                    code.push(';');
+                    code.push(file.code);
+                    code.push('\n');
+                    break;
+
+            }
+
+            if (options.sourceMap) {
+                combiner.addFile(file.path, file.code, file.map, {
+                    line: offset
+                });
+                offset += newlinesIn(file.code) + 1;
+            }
+
+        });
+
+        result = {
+            code: code.join('')
+        };
+
+        if (options.sourceMap) {
+            result.map = combiner.toSourceMap();
+        }
+
+        resolve(result);
+
     });
-
-    result = {
-        code: code.join('')
-    };
-
-    if (options.sourceMap) {
-        result.map = combiner.toSourceMap();
-    }
-
-    return result;
 
 }
 

--- a/src/concat/concat-files.js
+++ b/src/concat/concat-files.js
@@ -1,6 +1,5 @@
 var FileType = require('../file').type;
 var Combiner = require('./source-map-combiner');
-var requireify = require('./requireify');
 var Promise = require('bluebird');
 
 /**

--- a/src/css-validator/index.js
+++ b/src/css-validator/index.js
@@ -1,8 +1,8 @@
-var _ = require('underscore');
 var path = require('path');
 var StyleStats = require('stylestats');
 var TooManySelectorsError = require('../errors/too-many-selectors-error');
 var FileTooBigError = require('../errors/file-too-big-error');
+var Promise = require('bluebird');
 
 var MAX_CSS_SELECTORS = 4095;
 var MAX_FILE_SIZE_KB = 278;
@@ -75,29 +75,33 @@ var validateSelectors = function(bundle, result) {
 
 };
 
-var validate = function(bundle, css, cb) {
+var validate = function(bundle, css) {
 
-    if (!shouldValidate(bundle)) {
-        cb();
-        return;
-    }
+    return new Promise(function(resolve, reject) {
 
-    var stats = new StyleStats(css, cssStatsSettings);
-
-    stats.parse(function onCssStatsParsed(err, result) {
-
-        // If it's an error about an empty stylesheet, don't throw.
-        // This occurs on new bundles that have no styles yet.
-        // Otherwise, bubble the error up.
-        if (err && err.message !== 'Rule is not found.') {
-            cb(err);
+        if (!shouldValidate(bundle)) {
+            resolve();
             return;
         }
 
-        validateFileSize(bundle, result);
-        validateSelectors(bundle, result);
+        var stats = new StyleStats(css, cssStatsSettings);
 
-        cb();
+        stats.parse(function onCssStatsParsed(err, result) {
+
+            // If it's an error about an empty stylesheet, don't throw.
+            // This occurs on new bundles that have no styles yet.
+            // Otherwise, bubble the error up.
+            if (err && err.message !== 'Rule is not found.') {
+                reject(err);
+                return;
+            }
+
+            validateFileSize(bundle, result);
+            validateSelectors(bundle, result);
+
+            resolve();
+
+        });
 
     });
 

--- a/src/css-validator/index.js
+++ b/src/css-validator/index.js
@@ -80,11 +80,11 @@ var validate = function(bundle, css) {
     return new Promise(function(resolve, reject) {
 
         if (!shouldValidate(bundle)) {
-            resolve();
+            resolve(css);
             return;
         }
 
-        var stats = new StyleStats(css, cssStatsSettings);
+        var stats = new StyleStats(css.code, cssStatsSettings);
 
         stats.parse(function onCssStatsParsed(err, result) {
 
@@ -99,7 +99,7 @@ var validate = function(bundle, css) {
             validateFileSize(bundle, result);
             validateSelectors(bundle, result);
 
-            resolve();
+            resolve(css);
 
         });
 
@@ -107,6 +107,4 @@ var validate = function(bundle, css) {
 
 };
 
-module.exports = {
-    validate: validate
-};
+exports.validate = validate;

--- a/src/file/read-file.js
+++ b/src/file/read-file.js
@@ -11,7 +11,6 @@ function read(filePath) {
             var extractedCode = sourceMap.extract(code);
 
             resolve({
-                path: filePath,
                 code: extractedCode.code,
                 map: extractedCode.map
             });

--- a/src/file/write-file.js
+++ b/src/file/write-file.js
@@ -15,7 +15,6 @@ function write(code, map, fileType, outputPath, siteRoot) {
             }
 
             resolve({
-                path: outputPath,
                 code: code,
                 map: map
             });

--- a/src/process-code/process-async.js
+++ b/src/process-code/process-async.js
@@ -7,6 +7,7 @@ var Step = require('step');
  * @param {file.type} fileType
  * @param {object} options
  * @param {string} options.code
+ * @param {string} options.originalPath
  * @param {string} options.inputPath
  * @param {string} options.outputPath
  * @param {string} options.bundleDir
@@ -80,7 +81,14 @@ function processAsync(fileType, options, processFn) {
                     var onAfterProcessed = function(result) {
 
                         file.write(result.code, result.map, fileType, options.outputPath, options.siteRoot)
-                            .then(resolve)
+                            .then(function(written) {
+                                resolve({
+                                    code: written.code,
+                                    map: written.map,
+                                    path: options.inputPath,
+                                    originalPath: options.originalPath
+                                });
+                            })
                             .catch(reject);
 
                     };
@@ -92,7 +100,14 @@ function processAsync(fileType, options, processFn) {
                 } else {
 
                     file.read(options.outputPath)
-                        .then(resolve)
+                        .then(function(read) {
+                            resolve({
+                                code: read.code,
+                                map: read.map,
+                                path: options.inputPath,
+                                originalPath: options.originalPath
+                            });
+                        })
                         .catch(reject);
 
                 }

--- a/tests/unit/concat/concat-spec.js
+++ b/tests/unit/concat/concat-spec.js
@@ -21,10 +21,12 @@ describe('concat files', function() {
 
             givenFileTypeIs(FileType.JS);
             givenFile({
+                originalPath: 'C:\\foo\\file1.js',
                 path: 'C:\\foo\\file1.js',
                 code: 'var x = 1;'
             });
             givenFile({
+                originalPath: 'C:\\foo\\file2.js',
                 path: 'C:\\foo\\file2.js',
                 code: 'var y = 2;'
             });
@@ -57,10 +59,12 @@ describe('concat files', function() {
             givenSourceMapsEnabled();
             givenFileTypeIs(FileType.JS);
             givenFile({
+                originalPath: 'C:\\foo\\file1.js',
                 path: 'C:\\foo\\file1.js',
                 code: 'var x = 1;'
             });
             givenFile({
+                originalPath: 'C:\\foo\\file2.js',
                 path: 'C:\\foo\\file2.js',
                 code: 'var y = 2;'
             });
@@ -100,6 +104,7 @@ describe('concat files', function() {
             givenSourceMapsEnabled();
             givenFileTypeIs(FileType.JS);
             givenFile({
+                originalPath: 'C:\\foo\\file1.es6',
                 path: 'C:\\foo\\file1.js',
                 code:
                     '"use strict";\n' +
@@ -115,6 +120,7 @@ describe('concat files', function() {
                 }
             });
             givenFile({
+                originalPath: 'C:\\foo\\file2.jsx',
                 path: 'C:\\foo\\file2.js',
                 code:
                     'var file1 = React.createClass({\n' +
@@ -183,10 +189,12 @@ describe('concat files', function() {
             givenSourceMapsEnabled();
             givenFileTypeIs(FileType.JS);
             givenFile({
+                originalPath: 'C:\\foo\\file1.js',
                 path: 'C:\\foo\\file1.js',
                 code: 'var x = 1;'
             });
             givenFile({
+                originalPath: 'C:\\foo\\file2.es6',
                 path: 'C:\\foo\\file2.js',
                 code:
                     '"use strict";\n' +
@@ -241,6 +249,7 @@ describe('concat files', function() {
             givenSourceMapsEnabled();
             givenFileTypeIs(FileType.JS);
             givenFile({
+                originalPath: 'C:\\foo\\file1.es6',
                 path: 'C:\\foo\\file1.min.js',
                 code: '"use strict";var odds=evens.map(function(e){return e+1});',
                 map: {
@@ -251,6 +260,7 @@ describe('concat files', function() {
                 }
             });
             givenFile({
+                originalPath: 'C:\\foo\\file2.jsx',
                 path: 'C:\\foo\\file2.min.js',
                 code: 'var file1=React.createClass({displayName:"file1",render:function(){return React.createElement("div",null,"file1 ",this.props.name)}});',
                 map: {
@@ -295,10 +305,12 @@ describe('concat files', function() {
 
             givenFileTypeIs(FileType.CSS);
             givenFile({
+                originalPath: 'C:\\foo\\file1.css',
                 path: 'C:\\foo\\file1.css',
                 code: '.foo { background: red; }'
             });
             givenFile({
+                originalPath: 'C:\\foo\\file2.css',
                 path: 'C:\\foo\\file2.css',
                 code: '#bar { font-size: 10px; }'
             });
@@ -331,10 +343,12 @@ describe('concat files', function() {
             givenSourceMapsEnabled();
             givenFileTypeIs(FileType.CSS);
             givenFile({
+                originalPath: 'C:\\foo\\file1.css',
                 path: 'C:\\foo\\file1.css',
                 code: '.foo { background: red; }'
             });
             givenFile({
+                originalPath: 'C:\\foo\\file2.css',
                 path: 'C:\\foo\\file2.css',
                 code: '#bar { font-size: 10px; }'
             });
@@ -374,6 +388,7 @@ describe('concat files', function() {
             givenSourceMapsEnabled();
             givenFileTypeIs(FileType.CSS);
             givenFile({
+                originalPath: 'C:\\foo\\file1.less',
                 path: 'C:\\foo\\file1.css',
                 code:
                     '.less1 {\n' +
@@ -387,6 +402,7 @@ describe('concat files', function() {
                 }
             });
             givenFile({
+                originalPath: 'C:\\foo\\file2.scss',
                 path: 'C:\\foo\\file2.css',
                 code:
                     '#css-results #scss {\n' +
@@ -439,10 +455,12 @@ describe('concat files', function() {
             givenSourceMapsEnabled();
             givenFileTypeIs(FileType.CSS);
             givenFile({
+                originalPath: 'C:\\foo\\file1.css',
                 path: 'C:\\foo\\file1.css',
                 code: '.foo { background: red; }'
             });
             givenFile({
+                originalPath: 'C:\\foo\\file2.scss',
                 path: 'C:\\foo\\file2.css',
                 code:
                     '#css-results #scss {\n' +
@@ -493,6 +511,7 @@ describe('concat files', function() {
             givenSourceMapsEnabled();
             givenFileTypeIs(FileType.CSS);
             givenFile({
+                originalPath: 'C:\\foo\\file1.less',
                 path: 'C:\\foo\\file1.min.css',
                 code: '.less1{color:red}',
                 map: {
@@ -503,6 +522,7 @@ describe('concat files', function() {
                 }
             });
             givenFile({
+                originalPath: 'C:\\foo\\file2.scss',
                 path: 'C:\\foo\\file2.min.css',
                 code: '#css-results #scss{background:#008000}',
                 map: {

--- a/tests/unit/concat/concat-spec.js
+++ b/tests/unit/concat/concat-spec.js
@@ -6,7 +6,7 @@ describe('concat files', function() {
     var files,
         fileType,
         sourceMap,
-        code;
+        promise;
 
     beforeEach(function() {
 
@@ -35,18 +35,22 @@ describe('concat files', function() {
 
         });
 
-        it('Prefixes all lines with semi-colons and adds new lines between files.', function() {
+        it('Prefixes all lines with semi-colons and adds new lines between files.', function(done) {
 
             assertConcatenatedCodeIs(
                 ';var x = 1;\n' +
-                ';var y = 2;\n'
+                ';var y = 2;\n',
+                done
             );
 
         });
 
-        it('Does not generate a source map.', function() {
+        it('Does not generate a source map.', function(done) {
 
-            assertConcatenatedSourceMapIs(undefined);
+            assertConcatenatedSourceMapIs(
+                undefined,
+                done
+            );
 
         });
 
@@ -73,25 +77,29 @@ describe('concat files', function() {
 
         });
 
-        it('Prefixes all lines with semi-colons and adds new lines between files.', function() {
+        it('Prefixes all lines with semi-colons and adds new lines between files.', function(done) {
 
             assertConcatenatedCodeIs(
                 ';var x = 1;\n' +
-                ';var y = 2;\n'
+                ';var y = 2;\n',
+                done
             );
 
         });
 
-        it('Generates source map.', function() {
+        it('Generates source map.', function(done) {
 
-            assertConcatenatedSourceMapIs({
-                version: 3,
-                sources: [ 'C:\\foo\\file1.js', 'C:\\foo\\file2.js' ],
-                names: [  ],
-                mappings: 'AAAA;ACAA',
-                file: '',
-                sourceRoot : ''
-            });
+            assertConcatenatedSourceMapIs(
+                {
+                    version: 3,
+                    sources: [ 'C:\\foo\\file1.js', 'C:\\foo\\file2.js' ],
+                    names: [  ],
+                    mappings: 'AAAA;ACAA',
+                    file: '',
+                    sourceRoot : ''
+                },
+                done
+            );
 
         });
 
@@ -145,7 +153,7 @@ describe('concat files', function() {
 
         });
 
-        it('Prefixes all lines with semi-colons and adds new lines between files.', function() {
+        it('Prefixes all lines with semi-colons and adds new lines between files.', function(done) {
 
             assertConcatenatedCodeIs(
                 ';"use strict";\n' +
@@ -162,21 +170,25 @@ describe('concat files', function() {
                 '      "file1 ",\n' +
                 '      this.props.name\n' +
                 '    );\n' +
-                '  } });\n\n'
+                '  } });\n\n',
+                done
             );
 
         });
 
-        it('Generates source map.', function() {
+        it('Generates source map.', function(done) {
 
-            assertConcatenatedSourceMapIs({
-                version: 3,
-                sources: [ '/foo/file1.es6', '/foo/file2.jsx' ],
-                names: [  ],
-                mappings: ';;AAAA,IAAI,IAAI,GAAG,KAAK,CAAC,GAAG,CAAC,UAAA,CAAC;SAAI,CAAC,GAAG,CAAC;CAAA,CAAC,CAAC;ACAjC,IAAI,KAAK,GAAG,KAAK,CAAC,WAAW,CAAC;;AAAI,QAAM,EAAE,YAAW;AAAI,WAAO;;;;MAAY,IAAI,CAAC,KAAK,CAAC,IAAI;KAAO,CAAC;GAAG,EAAC,CAAC,CAAC',
-                file: '',
-                sourceRoot : ''
-            });
+            assertConcatenatedSourceMapIs(
+                {
+                    version: 3,
+                    sources: [ '/foo/file1.es6', '/foo/file2.jsx' ],
+                    names: [  ],
+                    mappings: ';;AAAA,IAAI,IAAI,GAAG,KAAK,CAAC,GAAG,CAAC,UAAA,CAAC;SAAI,CAAC,GAAG,CAAC;CAAA,CAAC,CAAC;ACAjC,IAAI,KAAK,GAAG,KAAK,CAAC,WAAW,CAAC;;AAAI,QAAM,EAAE,YAAW;AAAI,WAAO;;;;MAAY,IAAI,CAAC,KAAK,CAAC,IAAI;KAAO,CAAC;GAAG,EAAC,CAAC,CAAC',
+                    file: '',
+                    sourceRoot : ''
+                },
+                done
+            );
 
         });
 
@@ -214,7 +226,7 @@ describe('concat files', function() {
 
         });
         
-        it('Prefixes all lines with semi-colons and adds new lines between files.', function() {
+        it('Prefixes all lines with semi-colons and adds new lines between files.', function(done) {
         
             assertConcatenatedCodeIs(
                 ';var x = 1;\n' +
@@ -222,21 +234,25 @@ describe('concat files', function() {
                 '\n' +
                 'var odds = evens.map(function (v) {\n' +
                 '  return v + 1;\n' +
-                '});\n'
+                '});\n',
+                done
             );
         
         });
 
-        it('Generates source map.', function() {
+        it('Generates source map.', function(done) {
 
-            assertConcatenatedSourceMapIs({
-                version: 3,
-                sources: [ 'C:\\foo\\file1.js', '/foo/file2.es6' ],
-                names: [  ],
-                mappings: 'AAAA;;;ACAA,IAAI,IAAI,GAAG,KAAK,CAAC,GAAG,CAAC,UAAA,CAAC;SAAI,CAAC,GAAG,CAAC;CAAA,CAAC,CAAC',
-                file: '',
-                sourceRoot : ''
-            });
+            assertConcatenatedSourceMapIs(
+                {
+                    version: 3,
+                    sources: [ 'C:\\foo\\file1.js', '/foo/file2.es6' ],
+                    names: [  ],
+                    mappings: 'AAAA;;;ACAA,IAAI,IAAI,GAAG,KAAK,CAAC,GAAG,CAAC,UAAA,CAAC;SAAI,CAAC,GAAG,CAAC;CAAA,CAAC,CAAC',
+                    file: '',
+                    sourceRoot : ''
+                },
+                done
+            );
 
         });
 
@@ -275,25 +291,29 @@ describe('concat files', function() {
 
         });
 
-        it('Prefixes all lines with semi-colons and adds new lines between files.', function() {
+        it('Prefixes all lines with semi-colons and adds new lines between files.', function(done) {
 
             assertConcatenatedCodeIs(
                 ';"use strict";var odds=evens.map(function(e){return e+1});\n' +
-                ';var file1=React.createClass({displayName:"file1",render:function(){return React.createElement("div",null,"file1 ",this.props.name)}});\n'
+                ';var file1=React.createClass({displayName:"file1",render:function(){return React.createElement("div",null,"file1 ",this.props.name)}});\n',
+                done
             );
 
         });
 
-        it('Generates source map.', function() {
+        it('Generates source map.', function(done) {
 
-            assertConcatenatedSourceMapIs({
-                version: 3,
-                sources: [ '/foo/file1.es6', '/foo/file2.jsx' ],
-                names: [  ],
-                mappings: 'YAAA,IAAI,MAAO,MAAM,IAAI,SAAA,SAAK,GAAI;ACA9B,GAAI,CAAA,KAAK,CAAG,EAAA,IAAM,CAAD,CAAC,WAAW,CAAC,mBAAI,OAAQ,WAAe,MAAO,OAAA,kCAAY,KAAK,MAAM;ADAvF,IAAI,IAAI,GAAG,KAAK,CAAC,GAAG,CAAC,UAAA,CAAC;ACAY,QAAM,CDAd,CAAC,ACAe,GDAZ,CAAC,QCAsB;AAAI,CDA1B,CAAC,CAAC,QCA+B;;;;MAAY,IAAI,CAAC,KAAK,CAAC,IAAI;KAAO,CAAC;GAAG,EAAC,CAAC,CAAC',
-                file: '',
-                sourceRoot : ''
-            });
+            assertConcatenatedSourceMapIs(
+                {
+                    version: 3,
+                    sources: [ '/foo/file1.es6', '/foo/file2.jsx' ],
+                    names: [  ],
+                    mappings: 'YAAA,IAAI,MAAO,MAAM,IAAI,SAAA,SAAK,GAAI;ACA9B,GAAI,CAAA,KAAK,CAAG,EAAA,IAAM,CAAD,CAAC,WAAW,CAAC,mBAAI,OAAQ,WAAe,MAAO,OAAA,kCAAY,KAAK,MAAM;ADAvF,IAAI,IAAI,GAAG,KAAK,CAAC,GAAG,CAAC,UAAA,CAAC;ACAY,QAAM,CDAd,CAAC,ACAe,GDAZ,CAAC,QCAsB;AAAI,CDA1B,CAAC,CAAC,QCA+B;;;;MAAY,IAAI,CAAC,KAAK,CAAC,IAAI;KAAO,CAAC;GAAG,EAAC,CAAC,CAAC',
+                    file: '',
+                    sourceRoot : ''
+                },
+                done
+            );
 
         });
 
@@ -319,18 +339,22 @@ describe('concat files', function() {
 
         });
 
-        it('Adds new lines between files.', function() {
+        it('Adds new lines between files.', function(done) {
 
             assertConcatenatedCodeIs(
                 '.foo { background: red; }\n' +
-                '#bar { font-size: 10px; }\n'
+                '#bar { font-size: 10px; }\n',
+                done
             );
 
         });
 
-        it('Does not generate source map.', function() {
+        it('Does not generate source map.', function(done) {
 
-            assertConcatenatedSourceMapIs(undefined);
+            assertConcatenatedSourceMapIs(
+                undefined,
+                done
+            );
 
         });
 
@@ -357,25 +381,29 @@ describe('concat files', function() {
 
         });
 
-        it('Adds new lines between files.', function() {
+        it('Adds new lines between files.', function(done) {
 
             assertConcatenatedCodeIs(
                 '.foo { background: red; }\n' +
-                '#bar { font-size: 10px; }\n'
+                '#bar { font-size: 10px; }\n',
+                done
             );
 
         });
 
-        it('Generates source map.', function() {
+        it('Generates source map.', function(done) {
 
-            assertConcatenatedSourceMapIs({
-                version: 3,
-                sources: [ 'C:\\foo\\file1.css', 'C:\\foo\\file2.css' ],
-                names: [  ],
-                mappings: 'AAAA;ACAA',
-                file: '',
-                sourceRoot: ''
-            });
+            assertConcatenatedSourceMapIs(
+                {
+                    version: 3,
+                    sources: [ 'C:\\foo\\file1.css', 'C:\\foo\\file2.css' ],
+                    names: [  ],
+                    mappings: 'AAAA;ACAA',
+                    file: '',
+                    sourceRoot: ''
+                },
+                done
+            );
 
         });
 
@@ -420,7 +448,7 @@ describe('concat files', function() {
 
         });
 
-        it('Adds new lines between files.', function() {
+        it('Adds new lines between files.', function(done) {
 
             assertConcatenatedCodeIs(
                 '.less1 {\n' +
@@ -428,21 +456,25 @@ describe('concat files', function() {
                 '}\n\n' +
                 '#css-results #scss {\n' +
                 '  background: #008000; }\n' +
-                '\n\n'
+                '\n\n',
+                done
             );
 
         });
 
-        it('Generates source map.', function() {
+        it('Generates source map.', function(done) {
 
-            assertConcatenatedSourceMapIs({
-                version: 3,
-                sources: [ '/foo/file1.less', '/foo/file2.scss' ],
-                names: [  ],
-                mappings: 'AACA;EAAS,UAAA;;;ACAT,YAAY,CAAG,KAAK,CAAC;EAAE,UAAU,EADzB,OAAO,GAC8B',
-                file: '',
-                sourceRoot: ''
-            });
+            assertConcatenatedSourceMapIs(
+                {
+                    version: 3,
+                    sources: [ '/foo/file1.less', '/foo/file2.scss' ],
+                    names: [  ],
+                    mappings: 'AACA;EAAS,UAAA;;;ACAT,YAAY,CAAG,KAAK,CAAC;EAAE,UAAU,EADzB,OAAO,GAC8B',
+                    file: '',
+                    sourceRoot: ''
+                },
+                done
+            );
 
         });
 
@@ -478,27 +510,31 @@ describe('concat files', function() {
 
         });
 
-        it('Adds new lines between files.', function() {
+        it('Adds new lines between files.', function(done) {
 
             assertConcatenatedCodeIs(
                 '.foo { background: red; }\n' +
                 '#css-results #scss {\n' +
                 '  background: #008000; }\n' +
-                '\n\n'
+                '\n\n',
+                done
             );
 
         });
 
-        it('Generates source map.', function() {
+        it('Generates source map.', function(done) {
 
-            assertConcatenatedSourceMapIs({
-                version: 3,
-                sources: [ 'C:\\foo\\file1.css', '/foo/file2.scss' ],
-                names: [  ],
-                mappings: 'AAAA;ACCA,YAAY,CAAG,KAAK,CAAC;EAAE,UAAU,EADzB,OAAO,GAC8B',
-                file: '',
-                sourceRoot: ''
-            });
+            assertConcatenatedSourceMapIs(
+                {
+                    version: 3,
+                    sources: [ 'C:\\foo\\file1.css', '/foo/file2.scss' ],
+                    names: [  ],
+                    mappings: 'AAAA;ACCA,YAAY,CAAG,KAAK,CAAC;EAAE,UAAU,EADzB,OAAO,GAC8B',
+                    file: '',
+                    sourceRoot: ''
+                },
+                done
+            );
 
         });
 
@@ -537,25 +573,29 @@ describe('concat files', function() {
 
         });
 
-        it('Adds new lines between files.', function() {
+        it('Adds new lines between files.', function(done) {
 
             assertConcatenatedCodeIs(
                 '.less1{color:red}\n' +
-                '#css-results #scss{background:#008000}\n'
+                '#css-results #scss{background:#008000}\n',
+                done
             );
 
         });
 
-        it('Generates source map.', function() {
+        it('Generates source map.', function(done) {
 
-            assertConcatenatedSourceMapIs({
-                version: 3,
-                sources: [ '/foo/file1.less', '/foo/file2.scss' ],
-                names: [  ],
-                mappings: 'AACA;ACAA,EDAS,UAAA,ACAG,CAAG,KAAK,CAAC;EAAE,UAAU,EADzB,OAAO,GAC8B',
-                file: '',
-                sourceRoot: ''
-            });
+            assertConcatenatedSourceMapIs(
+                {
+                    version: 3,
+                    sources: [ '/foo/file1.less', '/foo/file2.scss' ],
+                    names: [  ],
+                    mappings: 'AACA;ACAA,EDAS,UAAA,ACAG,CAAG,KAAK,CAAC;EAAE,UAAU,EADzB,OAAO,GAC8B',
+                    file: '',
+                    sourceRoot: ''
+                },
+                done
+            );
 
         });
 
@@ -563,7 +603,7 @@ describe('concat files', function() {
 
     var concatFiles = function() {
 
-        code = concat.files({
+        promise = concat.files({
             files: files,
             fileType: fileType,
             sourceMap: sourceMap
@@ -589,15 +629,21 @@ describe('concat files', function() {
 
     };
 
-    var assertConcatenatedCodeIs = function(expected) {
+    var assertConcatenatedCodeIs = function(expected, done) {
 
-        expect(code.code).toEqual(expected);
+        promise.then(function(result) {
+            expect(result.code).toEqual(expected);
+            done();
+        });
 
     };
 
-    var assertConcatenatedSourceMapIs = function(expected) {
+    var assertConcatenatedSourceMapIs = function(expected, done) {
 
-        expect(code.map).toEqual(expected);
+        promise.then(function(result) {
+            expect(result.map).toEqual(expected);
+            done();
+        });
 
     };
 

--- a/tests/unit/css-validator-spec.js
+++ b/tests/unit/css-validator-spec.js
@@ -6,7 +6,7 @@ describe('CssValidator', function() {
 
     beforeEach(function(){
         css = '';
-    })
+    });
 
     it('Given valid CSS, does not throw error.', function(done) {
 
@@ -94,7 +94,7 @@ describe('CssValidator', function() {
 
     var givenToBigCss = function() {
         for(var i=0; i<25; i++) {
-            givenValidCss();;
+            givenValidCss();
         }
     };
 
@@ -104,22 +104,29 @@ describe('CssValidator', function() {
         }
     };
 
-    var validate = function(cb) {
-        cssValidator.validate(bundle, css, cb);
+    var validate = function() {
+        return cssValidator.validate(bundle, css);
     };
 
     var assertValidateThrowsError = function(done) {
-        validate(function(err) {
-            expect(err).not.toBeUndefined();
-            done();
-        });
+        validate()
+            .then(function() {
+                throw new Error('Should not have succeeded.');
+            })
+            .catch(function(err) {
+                expect(err).not.toBeUndefined();
+                done();
+            });
     };
 
     var assertValidateDoesNotThrowError = function(done) {
-        validate(function(err) {
-            expect(err).toBeUndefined();
-            done();
-        });
+        validate()
+            .then(function() {
+                done();
+            })
+            .catch(function(err) {
+                throw err;
+            });
     };
 
 });

--- a/tests/unit/css-validator-spec.js
+++ b/tests/unit/css-validator-spec.js
@@ -5,7 +5,9 @@ describe('CssValidator', function() {
         css;
 
     beforeEach(function(){
-        css = '';
+        css = {
+            code: ''
+        };
     });
 
     it('Given valid CSS, does not throw error.', function(done) {
@@ -100,7 +102,7 @@ describe('CssValidator', function() {
 
     var addCssRows = function(numRowsToAdd, cssToAdd) {
         for(var i=0; i<numRowsToAdd; i++) {
-            css += cssToAdd;
+            css.code += cssToAdd;
         }
     };
 
@@ -121,7 +123,8 @@ describe('CssValidator', function() {
 
     var assertValidateDoesNotThrowError = function(done) {
         validate()
-            .then(function() {
+            .then(function(result) {
+                expect(result).toEqual(css);
                 done();
             })
             .catch(function(err) {

--- a/tests/unit/file/read-file-spec.js
+++ b/tests/unit/file/read-file-spec.js
@@ -47,7 +47,6 @@ describe('read file', function() {
             .then(function(result) {
 
                 expect(result).toEqual({
-                    path: 'C:\\foo.js',
                     code: 'var x = 1;',
                     map: {
                         version: 3,

--- a/tests/unit/file/write-file-spec.js
+++ b/tests/unit/file/write-file-spec.js
@@ -91,7 +91,6 @@ describe('write file', function() {
             .then(function(result) {
 
                 expect(result).toEqual({
-                    path: outputPath,
                     code: 'var x = 1;',
                     map: undefined
                 });
@@ -167,7 +166,6 @@ describe('write file', function() {
             .then(function(result) {
 
                 expect(result).toEqual({
-                    path: outputPath,
                     code: 'var x = 1;',
                     map: {
                         version: 3,


### PR DESCRIPTION
@ZocDoc/polaris-devs 

Changes
--
- The library I'm using to generate the require-ified version of a bundle is async, so when we call the `concat` function on a require bundle it needs to be async as well. This updates our existing `concat` function to return a promise so we're properly set up for that.
- I've also made a change to maintain the original path of files so that we have it later in the pipeline when resolving `require` paths. By the time we get to the `concat` step, you previously would only have the path of the compiled file available, so ES6 and JSX file paths would be something like `App_CombinedStaging/bundlejs/Assets-foo-bar-file.js` rather than `Assets/foo/bar/file.es6`. If a file has a statement like `require('./file.es6')`, we wouldn't be able to properly resolve it without knowing the original path of `file.es6`.