### PR TITLE
Don't Re-minify

### DIFF
--- a/ZocDoc.Bundler.nuspec
+++ b/ZocDoc.Bundler.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>ZocDoc-Bundler</id>
-    <version>1.0.11</version>
+    <version>1.0.12</version>
     <title>ZocDoc - Bundler</title>
     <authors>ZocDoc, Inc.</authors>
     <owners>ZocDoc, Inc.</owners>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bundler",
   "private": true,
-  "version": "1.0.11",
+  "version": "1.0.12",
   "repository": {
     "type": "git",
     "url": "https://github.com/ZocDoc/Bundler"

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -321,7 +321,7 @@ function processJsBundle(options, jsBundle, bundleDir, jsFiles, bundleName, cb) 
               jsPath = path.join(bundleDir, jsFile),
               jsPathOutput = bundleFileUtility.getOutputFilePath(bundleName, jsPath, options),
               minJsPath = bundleFileUtility.getMinFileName(bundleName, jsPathOutput,  options);
-        
+
         var i = index++;
         pending++;
         Step(

--- a/src/minify/minify-css.js
+++ b/src/minify/minify-css.js
@@ -14,6 +14,10 @@ var path = require('path');
  */
 function minify(options) {
 
+    if (isAlreadyMinified(options.inputPath)) {
+        return Promise.resolve(options);
+    }
+
     return new Promise(function(resolve, reject) {
 
         try {
@@ -57,6 +61,12 @@ function minify(options) {
         }
 
     });
+
+}
+
+function isAlreadyMinified(filePath) {
+
+    return /\.min\.css$/.test(filePath);
 
 }
 

--- a/src/minify/minify-js.js
+++ b/src/minify/minify-js.js
@@ -11,6 +11,10 @@ var uglify = require('uglify-js');
  */
 function minify(options) {
 
+    if (isAlreadyMinified(options.inputPath)) {
+        return Promise.resolve(options);
+    }
+
     return new Promise(function(resolve, reject) {
 
         try {
@@ -32,6 +36,12 @@ function minify(options) {
         }
 
     });
+
+}
+
+function isAlreadyMinified(filePath) {
+
+    return /\.min\.js$/.test(filePath);
 
 }
 

--- a/tests/integration/basic-css-spec.js
+++ b/tests/integration/basic-css-spec.js
@@ -114,6 +114,20 @@ test.describeIntegrationTest("Css Bundling:", function() {
 
 	});
 
+    it('Given already minified CSS files, they are concatenated in the output bundle without re-minifying.', function() {
+
+        test.given.FileToBundle('file1.min.css', '.file1 { color:red; }');
+        test.given.FileToBundle('file2.min.css', '.file2 { color:red; }');
+
+        test.actions.Bundle();
+
+        test.assert.verifyBundleIs(
+            '.file1 { color:red; }\n' +
+            '.file2 { color:red; }\n'
+        );
+
+    });
+
 	var givenImages = function (imgFile) {
 	    var imgDir = test.given.TestDirectory + "/img";
 	    test.utility.CreateDirectory(imgDir);

--- a/tests/integration/basic-js-spec.js
+++ b/tests/integration/basic-js-spec.js
@@ -162,4 +162,18 @@ test.describeIntegrationTest("Js Bundling:", function() {
         );
 
     });
+
+    it('Given already minified JS files, they are concatenated in the output bundle without re-minifying.', function() {
+
+        test.given.FileToBundle('file1.min.js', '!function(){var s="file1";return s}();');
+        test.given.FileToBundle('file2.min.js', '!function(){var s="file2";return s}();');
+
+        test.actions.Bundle();
+
+        test.assert.verifyBundleIs(
+            ';!function(){var s="file1";return s}();\n' +
+            ';!function(){var s="file2";return s}();\n'
+        );
+
+    });
 });

--- a/tests/integration/minify/minify-css-spec.js
+++ b/tests/integration/minify/minify-css-spec.js
@@ -14,6 +14,25 @@ describe('minify CSS', function() {
 
     });
 
+    it('Given file is already minified, returns original code.', function(done) {
+
+        givenFilePathIs('C:\\foo\\bar.min.css');
+
+        minify(
+                '.foo {\n' +
+                '   background: red;\n' +
+                '}'
+            )
+            .then(assertResultIs(
+                '.foo {\n' +
+                '   background: red;\n' +
+                '}',
+                done
+            ))
+            .catch(throwError);
+
+    });
+
     it('Given code, returns minified code.', function(done) {
 
         minify(
@@ -104,6 +123,12 @@ describe('minify CSS', function() {
             inputPath: inputPath,
             siteRoot: 'C:\\'
         });
+
+    };
+
+    var givenFilePathIs = function(filePath) {
+
+        inputPath = filePath;
 
     };
 

--- a/tests/integration/minify/minify-js-spec.js
+++ b/tests/integration/minify/minify-js-spec.js
@@ -14,6 +14,25 @@ describe('minify JS', function() {
 
     });
 
+    it('Given file is already minified, returns original code.', function(done) {
+
+        givenFilePathIs('C:\\foo\\bar.min.js')
+
+        minify(
+                'function foo(x) {\n' +
+                '   return x * 2;\n' +
+                '}'
+            )
+            .then(assertResultIs(
+                'function foo(x) {\n' +
+                '   return x * 2;\n' +
+                '}',
+                done
+            ))
+            .catch(throwError);
+
+    });
+
     it('Given code, returns minified code.', function(done) {
 
         minify(
@@ -107,6 +126,12 @@ describe('minify JS', function() {
             sourceMap: sourceMap,
             inputPath: inputPath
         });
+
+    };
+
+    var givenFilePathIs = function(filePath) {
+
+        inputPath = filePath;
 
     };
 


### PR DESCRIPTION
@Pam-Hermanto-ZocDoc 

Changes
--
Updated Bundler to not re-minify files with `.min` in the filename. This applies to both JS and CSS, so if we end up exporting a CSS bundle from the component lib, we can avoid re-minifying that as well.