### PR TITLE
Webpack Bundles

### DIFF
--- a/ZocDoc.Bundler.nuspec
+++ b/ZocDoc.Bundler.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>ZocDoc-Bundler</id>
-    <version>1.0.13</version>
+    <version>1.0.14</version>
     <title>ZocDoc - Bundler</title>
     <authors>ZocDoc, Inc.</authors>
     <owners>ZocDoc, Inc.</owners>

--- a/ZocDoc.Bundler.nuspec
+++ b/ZocDoc.Bundler.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>ZocDoc-Bundler</id>
-    <version>1.0.14</version>
+    <version>1.0.15</version>
     <title>ZocDoc - Bundler</title>
     <authors>ZocDoc, Inc.</authors>
     <owners>ZocDoc, Inc.</owners>

--- a/ZocDoc.Bundler.nuspec
+++ b/ZocDoc.Bundler.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>ZocDoc-Bundler</id>
-    <version>1.0.12</version>
+    <version>1.0.13</version>
     <title>ZocDoc - Bundler</title>
     <authors>ZocDoc, Inc.</authors>
     <owners>ZocDoc, Inc.</owners>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bundler",
   "private": true,
-  "version": "1.0.13",
+  "version": "1.0.14",
   "repository": {
     "type": "git",
     "url": "https://github.com/ZocDoc/Bundler"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bundler",
   "private": true,
-  "version": "1.0.14",
+  "version": "1.0.15",
   "repository": {
     "type": "git",
     "url": "https://github.com/ZocDoc/Bundler"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bundler",
   "private": true,
-  "version": "1.0.12",
+  "version": "1.0.13",
   "repository": {
     "type": "git",
     "url": "https://github.com/ZocDoc/Bundler"

--- a/src/bundle-files.js
+++ b/src/bundle-files.js
@@ -140,7 +140,9 @@ BundleFiles.prototype.getBundles = function (fileType) {
 
 BundleFiles.prototype.getFilesInDirectory = function (fileType, bundleDir, currentDir) {
     var _this = this,
-        matcher = fileType == exports.BundleType.Javascript ? function(name) { return name.isJs(); } : function(name) { return name.isCss(); },
+        matcher = fileType == exports.BundleType.Javascript
+            ? function(name) { return name.isJs(); }
+            : function(name) { return name.isCss(); },
         dictionary = fileType == exports.BundleType.Javascript ? _this._jsDirectories : _this._cssDirectories
         output = [];
 

--- a/src/bundle-files.js
+++ b/src/bundle-files.js
@@ -138,11 +138,21 @@ BundleFiles.prototype.getBundles = function (fileType) {
     }
 };
 
-BundleFiles.prototype.getFilesInDirectory = function (fileType, bundleDir, currentDir) {
+BundleFiles.prototype.getFilesInDirectory = function (fileType, bundleDir, currentDir, options) {
     var _this = this,
         matcher = fileType == exports.BundleType.Javascript
-            ? function(name) { return name.isJs(); }
-            : function(name) { return name.isCss(); },
+            ? function(name) {
+                if (!options.webpack && name.endsWith('.min.js')) {
+                    return false;
+                }
+                return name.isJs();
+            }
+            : function(name) {
+                if (!options.webpack && name.endsWith('.min.css')) {
+                    return false;
+                }
+                return name.isCss();
+            },
         dictionary = fileType == exports.BundleType.Javascript ? _this._jsDirectories : _this._cssDirectories
         output = [];
 

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -177,7 +177,8 @@ function scanDir(allFiles, cb) {
                             var filesInDir = allFiles.getFilesInDirectory(
                                                 bundlefiles.BundleType.Javascript,
                                                 currentItem,
-                                                name
+                                                name,
+                                                options
                                             );
                             _.chain(filesInDir).filter(function(a) { return a.endsWith(".mustache")}).each(tmpFiles.addFile, tmpFiles);
                             _.chain(filesInDir).filter(function(a) { return a.endsWith(".js") || a.endsWith(".jsx") || a.endsWith(".es6") || a.endsWith(".json"); }).each(tmpFiles.addFile, tmpFiles);
@@ -226,7 +227,9 @@ function scanDir(allFiles, cb) {
                             var cssFiles = allFiles.getFilesInDirectory(
                                 bundlefiles.BundleType.Css,
                                 currentItem,
-                                name);
+                                name,
+                                options
+                            );
 
                             _.each(cssFiles, tmpFiles.addFile, tmpFiles);
                         }

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -61,6 +61,7 @@ var fs = require("fs"),
     minify = require('./minify'),
     concat = require('./concat'),
     file = require('./file'),
+    webpack = require('./webpack'),
     urlVersioning = null;
 
 bundleFileUtility = new bundleFileUtilityRequire.BundleFileUtility(fs);
@@ -297,6 +298,13 @@ function processJsBundle(options, jsBundle, bundleDir, jsFiles, bundleName, cb) 
 
     bundleStatsCollector.ClearStatsForBundle(jsBundle);
 
+    if (options.webpack) {
+        webpack.validate({
+            files: jsFiles,
+            fileType: file.type.JS
+        });
+    }
+
     jsFiles.forEach(function (file) {
         // Skip blank lines/files beginning with '.' or '#', but allow ../relative paths
 
@@ -384,25 +392,39 @@ function processJsBundle(options, jsBundle, bundleDir, jsFiles, bundleName, cb) 
 
             },
             function (js) {
-                allJsArr[i] = js;
-                var withMin = function (minJs) {
-                    allMinJsArr[i] = minJs;
+                if (options.webpack) {
 
-                    if (! --pending) whenDone();
-                };
+                    if (jsPath.endsWith('.min.js')) {
+                        allMinJsArr[i] = js;
+                    } else {
+                        allJsArr[i] = js;
+                    }
 
-                minify.js({
-                    code: js.code,
-                    map: js.map,
-                    originalPath: filePath,
-                    inputPath: jsPath,
-                    outputPath: minJsPath,
-                    bundleDir: bundleDir,
-                    bundleStatsCollector: bundleStatsCollector,
-                    sourceMap: options.sourcemaps,
-                    siteRoot: options.siterootdirectory,
-                    useTemplateDirs: options.usetemplatedirs
-                }).then(withMin).catch(handleError);
+                    whenDone();
+
+                } else {
+
+                    allJsArr[i] = js;
+                    var withMin = function (minJs) {
+                        allMinJsArr[i] = minJs;
+
+                        if (! --pending) whenDone();
+                    };
+
+                    minify.js({
+                        code: js.code,
+                        map: js.map,
+                        originalPath: filePath,
+                        inputPath: jsPath,
+                        outputPath: minJsPath,
+                        bundleDir: bundleDir,
+                        bundleStatsCollector: bundleStatsCollector,
+                        sourceMap: options.sourcemaps,
+                        siteRoot: options.siterootdirectory,
+                        useTemplateDirs: options.usetemplatedirs
+                    }).then(withMin).catch(handleError);
+
+                }
             }
         );
     });
@@ -466,6 +488,13 @@ function processCssBundle(options, cssBundle, bundleDir, cssFiles, bundleName, c
     };
 
     bundleStatsCollector.ClearStatsForBundle(cssBundle);
+
+    if (options.webpack) {
+        webpack.validate({
+            files: cssFiles,
+            fileType: file.type.CSS
+        });
+    }
 
     cssFiles.forEach(function (file) {
         if (!(file = file.trim())
@@ -536,25 +565,39 @@ function processCssBundle(options, cssBundle, bundleDir, cssFiles, bundleName, c
 
             },
             function (css) {
-                allCssArr[i] = css;
-                var withMin = function (minCss) {
-                    allMinCssArr[i] = minCss;
+                if (options.webpack) {
 
-                    if (! --pending) whenDone();
-                };
+                    if (cssPath.endsWith('.min.css')) {
+                        allMinCssArr[i] = css;
+                    } else {
+                        allCssArr[i] = css;
+                    }
 
-                minify.css({
-                    code: css.code,
-                    map: css.map,
-                    originalPath: filePath,
-                    inputPath: cssPath,
-                    outputPath: minCssPath,
-                    bundleDir: bundleDir,
-                    bundleStatsCollector: bundleStatsCollector,
-                    sourceMap: options.sourcemaps,
-                    siteRoot: options.siterootdirectory,
-                    useTemplateDirs: options.usetemplatedirs
-                }).then(withMin).catch(handleError);
+                    whenDone();
+
+                } else {
+
+                    allCssArr[i] = css;
+                    var withMin = function (minCss) {
+                        allMinCssArr[i] = minCss;
+
+                        if (!--pending) whenDone();
+                    };
+
+                    minify.css({
+                        code: css.code,
+                        map: css.map,
+                        originalPath: filePath,
+                        inputPath: cssPath,
+                        outputPath: minCssPath,
+                        bundleDir: bundleDir,
+                        bundleStatsCollector: bundleStatsCollector,
+                        sourceMap: options.sourcemaps,
+                        siteRoot: options.siterootdirectory,
+                        useTemplateDirs: options.usetemplatedirs
+                    }).then(withMin).catch(handleError);
+
+                }
             }
         );
     });

--- a/src/string-extensions.js
+++ b/src/string-extensions.js
@@ -47,13 +47,11 @@ String.prototype.NormalizeSlash = function (addInitialSlash, removeFinalSlash) {
 };
 
 String.prototype.isJs = function () {
-    if (this.endsWith('.min.js')) return false;
     if (this.endsWithAny(['.js', '.mustache', '.jsx', '.es6', '.json'])) return true;
     return false;
 }
 
 String.prototype.isCss = function () {
-    if (this.endsWith('.min.css')) return false;
     if (this.endsWithAny(['.css', '.less', '.sass', '.scss'])) return true;
     return false;
 }

--- a/src/webpack/index.js
+++ b/src/webpack/index.js
@@ -20,7 +20,7 @@ function validate(options) {
     options.files.forEach(function(file) {
 
         if (!file.endsWith(validExtension)) {
-            throw new Error('Invalid file ' + file + ' - only ' + validExtension + ' files may be added to webpack bundles');
+            throw new Error('Invalid file ' + file + ' - only ' + validExtension + ' files may be added to webpack bundles.');
         }
 
         if (file.endsWith(minExtension)) {

--- a/src/webpack/index.js
+++ b/src/webpack/index.js
@@ -1,0 +1,42 @@
+var _ = require('underscore');
+var FileType = require('../file').type;
+require('../string-extensions');
+
+/**
+ * @param {object} options
+ * @param {Array<object>} options.files
+ * @param {string} options.fileType
+ */
+function validate(options) {
+
+    var validExtension = options.fileType == FileType.JS ? '.js' : '.css';
+    var minExtension = '.min' + validExtension;
+
+    var fileHash = {};
+    options.files.forEach(function (file) {
+        fileHash[file] = true;
+    });
+
+    options.files.forEach(function(file) {
+
+        if (!file.endsWith(validExtension)) {
+            throw new Error('Invalid file ' + file + ' - only ' + validExtension + ' files may be added to webpack bundles');
+        }
+
+        if (file.endsWith(minExtension)) {
+            var nonMinFile = file.replace(minExtension, validExtension);
+            if (!fileHash[nonMinFile]) {
+                throw new Error(file + ' is missing a corresponding unminified file in the bundle.');
+            }
+        } else {
+            var minFile = file.replace(validExtension, minExtension);
+            if (!fileHash[minFile]) {
+                throw new Error(file + ' is missing a corresponding minified file in the bundle.');
+            }
+        }
+
+    });
+
+}
+
+exports.validate = validate;

--- a/tests/integration/webpack-option-spec.js
+++ b/tests/integration/webpack-option-spec.js
@@ -1,0 +1,329 @@
+var testDirectory = 'webpack-test-suite';
+var integrationTest = require('./helpers/jasmine-wrapper.js');
+var test = new integrationTest.Test(integrationTest.TestType.Js, testDirectory, console);
+
+test.describeIntegrationTest("Webpack bundles:", function() {
+
+    beforeEach(function() {
+
+        test.given.BundleOption('webpack');
+
+        test.given.StagingDirectoryIs('staging-dir');
+        test.given.OutputDirectoryIs('output-dir');
+
+    });
+
+    describe('js', function() {
+
+        beforeEach(function () {
+            test.resetTestType(integrationTest.TestType.Js);
+        });
+
+        it('Given webpack option and non JS file in the bundle, throws', function() {
+
+            test.given.FileToBundle(
+                'file1.js',
+                'var ZD = ZD || {};\n' +
+                'ZD.foo = "bar";'
+            );
+            test.given.FileToBundle(
+                'file1.min.js',
+                'var ZD=ZD||{};ZD.foo="bar"'
+            );
+            test.given.FileToBundle(
+                'file2.es6',
+                'var ZD=ZD||{};ZD.foo="bar"'
+            );
+
+            test.actions.Bundle();
+
+            test.assert.verifyErrorOnBundle('Error: Invalid file file2.es6 - only .js files may be added to webpack bundles.');
+
+        });
+
+        it('Given webpack option and unminified JS file without a corresponding minified JS file in the bundle, throws', function() {
+
+            test.given.FileToBundle(
+                'file1.js',
+                'var ZD = ZD || {};\n' +
+                'ZD.foo = "bar";'
+            );
+
+            test.actions.Bundle();
+
+            test.assert.verifyErrorOnBundle('Error: file1.js is missing a corresponding minified file in the bundle.');
+
+        });
+
+        it('Given webpack option and one file pair in bundle, staging bundle contains only unminified JS file.', function() {
+
+            test.given.FileToBundle(
+                'file1.js',
+                'var ZD = ZD || {};\n' +
+                'ZD.foo = "bar";'
+            );
+            test.given.FileToBundle(
+                'file1.min.js',
+                'var ZD=ZD||{};ZD.foo="bar"'
+            );
+
+            test.actions.Bundle();
+
+            test.assert.verifyFileAndContentsAre(
+                test.given.StagingDirectory + '/testjs',
+                'test.js',
+                ';var ZD = ZD || {};\n' +
+                'ZD.foo = "bar";\n'
+            );
+
+        });
+
+        it('Given webpack option and multiple file pairs in bundle, staging bundle contains only unminified JS files.', function() {
+
+            test.given.FileToBundle(
+                'file1.js',
+                'var ZD = ZD || {};\n' +
+                'ZD.foo = "bar";'
+            );
+            test.given.FileToBundle(
+                'file1.min.js',
+                'var ZD=ZD||{};ZD.foo="bar"'
+            );
+            test.given.FileToBundle(
+                'file2.js',
+                'var ZD = ZD || {};\n' +
+                'ZD.bar = "foo";'
+            );
+            test.given.FileToBundle(
+                'file2.min.js',
+                'var ZD=ZD||{};ZD.bar="foo"'
+            );
+
+            test.actions.Bundle();
+
+            test.assert.verifyFileAndContentsAre(
+                test.given.StagingDirectory + '/testjs',
+                'test.js',
+                ';var ZD = ZD || {};\n' +
+                'ZD.foo = "bar";\n' +
+                ';var ZD = ZD || {};\n' +
+                'ZD.bar = "foo";\n'
+            );
+
+        });
+
+        it('Given webpack option and one file pair in bundle, output bundle contains only minified JS file.', function() {
+
+            test.given.FileToBundle(
+                'file1.js',
+                'var ZD = ZD || {};\n' +
+                'ZD.foo = "bar";'
+            );
+            test.given.FileToBundle(
+                'file1.min.js',
+                'var ZD=ZD||{};ZD.foo="bar"'
+            );
+
+            test.actions.Bundle();
+
+            test.assert.verifyBundleIs(
+                ';var ZD=ZD||{};ZD.foo="bar"\n'
+            );
+
+        });
+
+        it('Given webpack option and multiple file pairs in bundle, output bundle contains only minified JS files.', function() {
+
+            test.given.FileToBundle(
+                'file1.js',
+                'var ZD = ZD || {};\n' +
+                'ZD.foo = "bar";'
+            );
+            test.given.FileToBundle(
+                'file1.min.js',
+                'var ZD=ZD||{};ZD.foo="bar"'
+            );
+            test.given.FileToBundle(
+                'file2.js',
+                'var ZD = ZD || {};\n' +
+                'ZD.bar = "foo";'
+            );
+            test.given.FileToBundle(
+                'file2.min.js',
+                'var ZD=ZD||{};ZD.bar="foo"'
+            );
+
+            test.actions.Bundle();
+
+            test.assert.verifyBundleIs(
+                ';var ZD=ZD||{};ZD.foo="bar"\n' +
+                ';var ZD=ZD||{};ZD.bar="foo"\n'
+            );
+
+        });
+
+    });
+
+    describe('css', function() {
+
+        beforeEach(function () {
+            test.resetTestType(integrationTest.TestType.Css);
+        });
+
+        it('Given webpack option and non CSS file in the bundle, throws', function() {
+
+            test.given.FileToBundle(
+                'file1.css',
+                '.foo {\n' +
+                '  background: red;\n' +
+                '}'
+            );
+            test.given.FileToBundle(
+                'file1.min.css',
+                '.foo{background:red}'
+            );
+            test.given.FileToBundle(
+                'file2.less',
+                '@red: red;'
+            );
+
+            test.actions.Bundle();
+
+            test.assert.verifyErrorOnBundle('Error: Invalid file file2.less - only .css files may be added to webpack bundles.');
+
+        });
+
+        it('Given webpack option and unminified CSS file without a corresponding minified CSS file in the bundle, throws', function() {
+
+            test.given.FileToBundle(
+                'file1.css',
+                '.foo {\n' +
+                '  background: red;\n' +
+                '}'
+            );
+
+            test.actions.Bundle();
+
+            test.assert.verifyErrorOnBundle('Error: file1.css is missing a corresponding minified file in the bundle.');
+
+        });
+
+        it('Given webpack option and one file pair in bundle, staging bundle contains only unminified CSS file.', function() {
+
+            test.given.FileToBundle(
+                'file1.css',
+                '.foo {\n' +
+                '  background: red;\n' +
+                '}'
+            );
+            test.given.FileToBundle(
+                'file1.min.css',
+                '.foo{background:red}'
+            );
+
+            test.actions.Bundle();
+
+            test.assert.verifyFileAndContentsAre(
+                test.given.StagingDirectory + '/testcss',
+                'test.css',
+                '.foo {\n' +
+                '  background: red;\n' +
+                '}\n'
+            );
+
+        });
+
+        it('Given webpack option and multiple file pairs in bundle, staging bundle contains only unminified JS files.', function() {
+
+            test.given.FileToBundle(
+                'file1.css',
+                '.foo {\n' +
+                '  background: red;\n' +
+                '}'
+            );
+            test.given.FileToBundle(
+                'file1.min.css',
+                '.foo{background:red}'
+            );
+            test.given.FileToBundle(
+                'file2.css',
+                '.bar {\n' +
+                '  background: blue;\n' +
+                '}'
+            );
+            test.given.FileToBundle(
+                'file2.min.css',
+                '.bar{background:blue}'
+            );
+
+            test.actions.Bundle();
+
+            test.assert.verifyFileAndContentsAre(
+                test.given.StagingDirectory + '/testcss',
+                'test.css',
+                '.foo {\n' +
+                '  background: red;\n' +
+                '}\n' +
+                '.bar {\n' +
+                '  background: blue;\n' +
+                '}\n'
+            );
+
+        });
+
+        it('Given webpack option and one file pair in bundle, output bundle contains only minified CSS file.', function() {
+
+            test.given.FileToBundle(
+                'file1.css',
+                '.foo {\n' +
+                '  background: red;\n' +
+                '}'
+            );
+            test.given.FileToBundle(
+                'file1.min.css',
+                '.foo{background:red}'
+            );
+
+            test.actions.Bundle();
+
+            test.assert.verifyBundleIs(
+                '.foo{background:red}\n'
+            );
+
+        });
+
+        it('Given webpack option and multiple file pairs in bundle, output bundle contains only minified CSS files.', function() {
+
+            test.given.FileToBundle(
+                'file1.css',
+                '.foo {\n' +
+                '  background: red;\n' +
+                '}'
+            );
+            test.given.FileToBundle(
+                'file1.min.css',
+                '.foo{background:red}'
+            );
+            test.given.FileToBundle(
+                'file2.css',
+                '.bar {\n' +
+                '  background: blue;\n' +
+                '}'
+            );
+            test.given.FileToBundle(
+                'file2.min.css',
+                '.bar{background:blue}'
+            );
+
+            test.actions.Bundle();
+
+            test.assert.verifyBundleIs(
+                '.foo{background:red}\n' +
+                '.bar{background:blue}\n'
+            );
+
+        });
+
+    });
+
+});

--- a/tests/integration/webpack-option-spec.js
+++ b/tests/integration/webpack-option-spec.js
@@ -1,6 +1,6 @@
 var testDirectory = 'webpack-test-suite';
 var integrationTest = require('./helpers/jasmine-wrapper.js');
-var test = new integrationTest.Test(integrationTest.TestType.Js, testDirectory, console);
+var test = new integrationTest.Test(integrationTest.TestType.Js, testDirectory);
 
 test.describeIntegrationTest("Webpack bundles:", function() {
 
@@ -158,6 +158,102 @@ test.describeIntegrationTest("Webpack bundles:", function() {
             test.assert.verifyBundleIs(
                 ';var ZD=ZD||{};ZD.foo="bar"\n' +
                 ';var ZD=ZD||{};ZD.bar="foo"\n'
+            );
+
+        });
+
+        it('Given webpack and sourcemap options and files without source maps, staging bundle does not contain source maps.', function() {
+
+            test.given.CommandLineOption('-sourcemaps');
+            test.given.FileToBundle(
+                'file1.js',
+                'var ZD = ZD || {};\n' +
+                'ZD.foo = "bar";'
+            );
+            test.given.FileToBundle(
+                'file1.min.js',
+                'var ZD=ZD||{};ZD.foo="bar"'
+            );
+
+            test.actions.Bundle();
+
+            test.assert.verifyFileAndContentsAre(
+                test.given.StagingDirectory + '/testjs',
+                'test.js',
+                ';var ZD = ZD || {};\n' +
+                'ZD.foo = "bar";\n'
+            );
+
+        });
+
+        it('Given webpack and sourcemap options and files without source maps, output bundle does not contain source maps.', function() {
+
+            test.given.CommandLineOption('-sourcemaps');
+            test.given.FileToBundle(
+                'file1.js',
+                'var ZD = ZD || {};\n' +
+                'ZD.foo = "bar";'
+            );
+            test.given.FileToBundle(
+                'file1.min.js',
+                'var ZD=ZD||{};ZD.foo="bar"'
+            );
+
+            test.actions.Bundle();
+
+            test.assert.verifyBundleIs(
+                ';var ZD=ZD||{};ZD.foo="bar"\n'
+            );
+
+        });
+
+        it('Given webpack and sourcemap options and files with source maps, staging bundle does not contain source maps.', function() {
+
+            test.given.CommandLineOption('-sourcemaps');
+            test.given.FileToBundle(
+                'file1.js',
+                'var ZD = ZD || {};\n' +
+                'ZD.foo = "bar";\n' +
+                '//# sourceMappingURL=file1.js.map'
+            );
+            test.given.FileToBundle(
+                'file1.min.js',
+                'var ZD=ZD||{};ZD.foo="bar"\n' +
+                '//# sourceMappingURL=file1.min.js.map'
+            );
+
+            test.actions.Bundle();
+
+            test.assert.verifyFileAndContentsAre(
+                test.given.StagingDirectory + '/testjs',
+                'test.js',
+                ';var ZD = ZD || {};\n' +
+                'ZD.foo = "bar";\n' +
+                '\n'
+            );
+
+        });
+
+        it('Given webpack and sourcemap options and files with source maps, output bundle does not contain source maps.', function() {
+
+            test.given.CommandLineOption('-sourcemaps');
+            test.given.FileToBundle(
+                'file1.js',
+                'var ZD = ZD || {};\n' +
+                'ZD.foo = "bar";\n' +
+                '//# sourceMappingURL=file1.js.map'
+            );
+            test.given.FileToBundle(
+                'file1.min.js',
+                'var ZD=ZD||{};ZD.foo="bar"\n' +
+                '//# sourceMappingURL=file1.min.js.map'
+            );
+
+            test.actions.Bundle();
+
+            test.assert.verifyBundleIs(
+                ';var ZD=ZD||{};ZD.foo="bar"\n' +
+                '\n'
             );
 
         });
@@ -320,6 +416,108 @@ test.describeIntegrationTest("Webpack bundles:", function() {
             test.assert.verifyBundleIs(
                 '.foo{background:red}\n' +
                 '.bar{background:blue}\n'
+            );
+
+        });
+
+        it('Given webpack and sourcemap options and files without source maps, staging bundle does not contain source maps.', function() {
+
+            test.given.CommandLineOption('-sourcemaps');
+            test.given.FileToBundle(
+                'file1.css',
+                '.foo {\n' +
+                '  background: red;\n' +
+                '}'
+            );
+            test.given.FileToBundle(
+                'file1.min.css',
+                '.foo{background:red}'
+            );
+
+            test.actions.Bundle();
+
+            test.assert.verifyFileAndContentsAre(
+                test.given.StagingDirectory + '/testcss',
+                'test.css',
+                '.foo {\n' +
+                '  background: red;\n' +
+                '}\n'
+            );
+
+        });
+
+        it('Given webpack and sourcemap options and files without source maps, output bundle does not contain source maps.', function() {
+
+            test.given.CommandLineOption('-sourcemaps');
+            test.given.FileToBundle(
+                'file1.css',
+                '.foo {\n' +
+                '  background: red;\n' +
+                '}'
+            );
+            test.given.FileToBundle(
+                'file1.min.css',
+                '.foo{background:red}'
+            );
+
+            test.actions.Bundle();
+
+            test.assert.verifyBundleIs(
+                '.foo{background:red}\n'
+            );
+
+        });
+
+        it('Given webpack and sourcemap options and files with source maps, staging bundle does not contain source maps.', function() {
+
+            test.given.CommandLineOption('-sourcemaps');
+            test.given.FileToBundle(
+                'file1.css',
+                '.foo {\n' +
+                '  background: red;\n' +
+                '}\n' +
+                '//# sourceMappingURL=file1.css.map'
+            );
+            test.given.FileToBundle(
+                'file1.min.css',
+                '.foo{background:red}\n' +
+                '//# sourceMappingURL=file1.min.css.map'
+            );
+
+            test.actions.Bundle();
+
+            test.assert.verifyFileAndContentsAre(
+                test.given.StagingDirectory + '/testcss',
+                'test.css',
+                '.foo {\n' +
+                '  background: red;\n' +
+                '}\n' +
+                '\n'
+            );
+
+        });
+
+        it('Given webpack and sourcemap options and files with source maps, output bundle does not contain source maps.', function() {
+
+            test.given.CommandLineOption('-sourcemaps');
+            test.given.FileToBundle(
+                'file1.css',
+                '.foo {\n' +
+                '  background: red;\n' +
+                '}\n' +
+                '//# sourceMappingURL=file1.css.map'
+            );
+            test.given.FileToBundle(
+                'file1.min.css',
+                '.foo{background:red}\n' +
+                '//# sourceMappingURL=file1.min.css.map'
+            );
+
+            test.actions.Bundle();
+
+            test.assert.verifyBundleIs(
+                '.foo{background:red}\n' +
+                '\n'
             );
 
         });

--- a/tests/integration/webpack-option-spec.js
+++ b/tests/integration/webpack-option-spec.js
@@ -55,6 +55,33 @@ test.describeIntegrationTest("Webpack bundles:", function() {
 
         });
 
+        it('Given webpack option and one file pair in bundle grabbed from folder, staging bundle contains only unminified JS file.', function() {
+
+            test.given.SubDirectory('scripts');
+            test.given.FileNotInBundleInSubDirectory(
+                'scripts',
+                'file1.js',
+                'var ZD = ZD || {};\n' +
+                'ZD.foo = "bar";'
+            );
+            test.given.FileNotInBundleInSubDirectory(
+                'scripts',
+                'file1.min.js',
+                'var ZD=ZD||{};ZD.foo="bar"'
+            );
+            test.given.DirectoryToBundle('scripts');
+
+            test.actions.Bundle();
+
+            test.assert.verifyFileAndContentsAre(
+                test.given.StagingDirectory + '/testjs',
+                'test.js',
+                ';var ZD = ZD || {};\n' +
+                'ZD.foo = "bar";\n'
+            );
+
+        });
+
         it('Given webpack option and one file pair in bundle, staging bundle contains only unminified JS file.', function() {
 
             test.given.FileToBundle(
@@ -108,6 +135,30 @@ test.describeIntegrationTest("Webpack bundles:", function() {
                 'ZD.foo = "bar";\n' +
                 ';var ZD = ZD || {};\n' +
                 'ZD.bar = "foo";\n'
+            );
+
+        });
+
+        it('Given webpack option and one file pair in bundle grabbed from folder, output bundle contains only minified JS file.', function() {
+
+            test.given.SubDirectory('scripts');
+            test.given.FileNotInBundleInSubDirectory(
+                'scripts',
+                'file1.js',
+                'var ZD = ZD || {};\n' +
+                'ZD.foo = "bar";'
+            );
+            test.given.FileNotInBundleInSubDirectory(
+                'scripts',
+                'file1.min.js',
+                'var ZD=ZD||{};ZD.foo="bar"'
+            );
+            test.given.DirectoryToBundle('scripts');
+
+            test.actions.Bundle();
+
+            test.assert.verifyBundleIs(
+                ';var ZD=ZD||{};ZD.foo="bar"\n'
             );
 
         });
@@ -304,6 +355,35 @@ test.describeIntegrationTest("Webpack bundles:", function() {
 
         });
 
+        it('Given webpack option and one file pair in bundle grabbed from folder, staging bundle contains only unminified CSS file.', function() {
+
+            test.given.SubDirectory('styles');
+            test.given.FileNotInBundleInSubDirectory(
+                'styles',
+                'file1.css',
+                '.foo {\n' +
+                '  background: red;\n' +
+                '}'
+            );
+            test.given.FileNotInBundleInSubDirectory(
+                'styles',
+                'file1.min.css',
+                '.foo{background:red}'
+            );
+            test.given.DirectoryToBundle('styles');
+
+            test.actions.Bundle();
+
+            test.assert.verifyFileAndContentsAre(
+                test.given.StagingDirectory + '/testcss',
+                'test.css',
+                '.foo {\n' +
+                '  background: red;\n' +
+                '}\n'
+            );
+
+        });
+
         it('Given webpack option and one file pair in bundle, staging bundle contains only unminified CSS file.', function() {
 
             test.given.FileToBundle(
@@ -363,6 +443,31 @@ test.describeIntegrationTest("Webpack bundles:", function() {
                 '.bar {\n' +
                 '  background: blue;\n' +
                 '}\n'
+            );
+
+        });
+
+        it('Given webpack option and one file pair in bundle grabbed from folder, output bundle contains only minified CSS file.', function() {
+
+            test.given.SubDirectory('styles');
+            test.given.FileNotInBundleInSubDirectory(
+                'styles',
+                'file1.css',
+                '.foo {\n' +
+                '  background: red;\n' +
+                '}'
+            );
+            test.given.FileNotInBundleInSubDirectory(
+                'styles',
+                'file1.min.css',
+                '.foo{background:red}'
+            );
+            test.given.DirectoryToBundle('styles');
+
+            test.actions.Bundle();
+
+            test.assert.verifyBundleIs(
+                '.foo{background:red}\n'
             );
 
         });

--- a/tests/unit/bundle-files-spec.js
+++ b/tests/unit/bundle-files-spec.js
@@ -93,8 +93,23 @@ describe("BundleFiles.", function () {
 
           var jsFilesInDir = files.getFilesInDirectory(bundlefiles.BundleType.Javascript,
                                   "/tests/test1",
-                                  ""
+                                  "",
+                                  {}
                               );
+
+          expect(jsFilesInDir.length).toBe(3);
+          expect(jsFilesInDir.contains("/file.js")).toBe(true);
+          expect(jsFilesInDir.contains("/file.mustache")).toBe(true);
+          expect(jsFilesInDir.contains("/file.json")).toBe(true);
+      });
+
+      it("Gets only .js and .min.js file types given webpack bundle", function () {
+
+          var jsFilesInDir = files.getFilesInDirectory(bundlefiles.BundleType.Javascript,
+              "/tests/test1",
+              "",
+              { webpack: true }
+          );
 
           expect(jsFilesInDir.length).toBe(4);
           expect(jsFilesInDir.contains("/file.js")).toBe(true);
@@ -107,12 +122,12 @@ describe("BundleFiles.", function () {
 
           var jsFilesInDir = files.getFilesInDirectory(bundlefiles.BundleType.Javascript,
                                   "/tests/test1",
-                                  "/test1"
+                                  "/test1",
+                                  {}
                               );
 
-          expect(jsFilesInDir.length).toBe(4);
+          expect(jsFilesInDir.length).toBe(3);
           expect(jsFilesInDir.contains("/test1/file.js")).toBe(true);
-          expect(jsFilesInDir.contains("/test1/file.min.js")).toBe(true);
           expect(jsFilesInDir.contains("/test1/file.mustache")).toBe(true);
           expect(jsFilesInDir.contains("/test1/file.json")).toBe(true);
       });
@@ -121,12 +136,12 @@ describe("BundleFiles.", function () {
 
           var jsFilesInDir = files.getFilesInDirectory(bundlefiles.BundleType.Javascript,
                                   "/tests",
-                                  ""
+                                  "",
+                                  {}
                               );
 
-          expect(jsFilesInDir.length).toBe(8);
+          expect(jsFilesInDir.length).toBe(7);
           expect(jsFilesInDir.contains("/test1/file.js")).toBe(true);
-          expect(jsFilesInDir.contains("/test1/file.min.js")).toBe(true);
           expect(jsFilesInDir.contains("/test4/file.js")).toBe(true);
           expect(jsFilesInDir.contains("/test5/file.mustache")).toBe(true);
           expect(jsFilesInDir.contains("/test5/file.json")).toBe(true);
@@ -136,7 +151,8 @@ describe("BundleFiles.", function () {
 
           var jsFilesInDir = files.getFilesInDirectory(bundlefiles.BundleType.Javascript,
                                   "/tests/test5/",
-                                  "test5/"
+                                  "test5/",
+                                  {}
                               );
 
           expect(jsFilesInDir.length).toBe(2);
@@ -149,7 +165,8 @@ describe("BundleFiles.", function () {
 
           var jsFilesInDir = files.getFilesInDirectory(bundlefiles.BundleType.Javascript,
                                   "/casing/tests",
-                                  "output/"
+                                  "output/",
+                                  {}
                               );
 
           expect(jsFilesInDir.length).toBe(1);
@@ -160,7 +177,8 @@ describe("BundleFiles.", function () {
 
           var jsFilesInDir = files.getFilesInDirectory(bundlefiles.BundleType.Javascript,
                                   "/casing/tests/",
-                                  "output"
+                                  "output",
+                                  {}
                               );
 
           expect(jsFilesInDir.length).toBe(1);
@@ -172,7 +190,8 @@ describe("BundleFiles.", function () {
           var shouldThrow = function () {
               files.getFilesInDirectory(bundlefiles.BundleType.Javascript,
                                       "/not_a_valid_directory",
-                                      "output"
+                                      "output",
+                                      {}
                                   );
           };
 
@@ -186,8 +205,24 @@ describe("BundleFiles.", function () {
 
           var cssFilesInDir = files.getFilesInDirectory(bundlefiles.BundleType.Css,
                                   "/tests/test2",
-                                  ""
+                                  "",
+                                  {}
                               );
+
+          expect(cssFilesInDir.length).toBe(4);
+          expect(cssFilesInDir.contains("/file.css")).toBe(true);
+          expect(cssFilesInDir.contains("/file.less")).toBe(true);
+          expect(cssFilesInDir.contains("/file.sass")).toBe(true);
+          expect(cssFilesInDir.contains("/directory/file.scss")).toBe(true);
+      });
+
+      it("Gets only .css and .min.css file types given webpack bundle", function () {
+
+          var cssFilesInDir = files.getFilesInDirectory(bundlefiles.BundleType.Css,
+              "/tests/test2",
+              "",
+              { webpack: true }
+          );
 
           expect(cssFilesInDir.length).toBe(5);
           expect(cssFilesInDir.contains("/file.css")).toBe(true);
@@ -201,12 +236,12 @@ describe("BundleFiles.", function () {
 
           var cssFilesInDir = files.getFilesInDirectory(bundlefiles.BundleType.Css,
                                   "/tests/test2",
-                                  "/test2"
+                                  "/test2",
+                                  {}
                               );
 
-          expect(cssFilesInDir.length).toBe(5);
+          expect(cssFilesInDir.length).toBe(4);
           expect(cssFilesInDir.contains("/test2/file.css")).toBe(true);
-          expect(cssFilesInDir.contains("/test2/file.min.css")).toBe(true);
           expect(cssFilesInDir.contains("/test2/file.less")).toBe(true);
           expect(cssFilesInDir.contains("/test2/file.sass")).toBe(true);
           expect(cssFilesInDir.contains("/test2/directory/file.scss")).toBe(true);
@@ -216,12 +251,12 @@ describe("BundleFiles.", function () {
 
           var cssFilesInDir = files.getFilesInDirectory(bundlefiles.BundleType.Css,
                                   "/tests",
-                                  ""
+                                  "",
+                                  {}
                               );
 
-          expect(cssFilesInDir.length).toBe(9);
+          expect(cssFilesInDir.length).toBe(8);
           expect(cssFilesInDir.contains("/test2/file.css")).toBe(true);
-          expect(cssFilesInDir.contains("/test2/file.min.css")).toBe(true);
           expect(cssFilesInDir.contains("/test3/file.css")).toBe(true);
           expect(cssFilesInDir.contains("/test6/file.css")).toBe(true);
       });
@@ -230,7 +265,8 @@ describe("BundleFiles.", function () {
 
           var cssFilesInDir = files.getFilesInDirectory(bundlefiles.BundleType.Css,
                                   "/tests/test3/",
-                                  "test3/"
+                                  "test3/",
+                                  {}
                               );
 
           expect(cssFilesInDir.length).toBe(1);
@@ -241,7 +277,8 @@ describe("BundleFiles.", function () {
 
           var cssFilesInDir = files.getFilesInDirectory(bundlefiles.BundleType.Css,
                                   "/casing/tests",
-                                  "output/"
+                                  "output/",
+                                  {}
                               );
 
           expect(cssFilesInDir.length).toBe(1);
@@ -252,7 +289,8 @@ describe("BundleFiles.", function () {
 
           var cssFilesInDir = files.getFilesInDirectory(bundlefiles.BundleType.Css,
                                   "/casing/tests/",
-                                  "output"
+                                  "output",
+                                  {}
                               );
 
           expect(cssFilesInDir.length).toBe(1);
@@ -264,7 +302,8 @@ describe("BundleFiles.", function () {
           var shouldThrow = function () {
               files.getFilesInDirectory(bundlefiles.BundleType.Css,
                                       "/not_a_valid_directory",
-                                      "output"
+                                      "output",
+                                      {}
                                   );
           };
 

--- a/tests/unit/bundle-files-spec.js
+++ b/tests/unit/bundle-files-spec.js
@@ -96,8 +96,9 @@ describe("BundleFiles.", function () {
                                   ""
                               );
 
-          expect(jsFilesInDir.length).toBe(3);
+          expect(jsFilesInDir.length).toBe(4);
           expect(jsFilesInDir.contains("/file.js")).toBe(true);
+          expect(jsFilesInDir.contains("/file.min.js")).toBe(true);
           expect(jsFilesInDir.contains("/file.mustache")).toBe(true);
           expect(jsFilesInDir.contains("/file.json")).toBe(true);
       });
@@ -109,8 +110,9 @@ describe("BundleFiles.", function () {
                                   "/test1"
                               );
 
-          expect(jsFilesInDir.length).toBe(3);
+          expect(jsFilesInDir.length).toBe(4);
           expect(jsFilesInDir.contains("/test1/file.js")).toBe(true);
+          expect(jsFilesInDir.contains("/test1/file.min.js")).toBe(true);
           expect(jsFilesInDir.contains("/test1/file.mustache")).toBe(true);
           expect(jsFilesInDir.contains("/test1/file.json")).toBe(true);
       });
@@ -122,8 +124,9 @@ describe("BundleFiles.", function () {
                                   ""
                               );
 
-          expect(jsFilesInDir.length).toBe(7);
+          expect(jsFilesInDir.length).toBe(8);
           expect(jsFilesInDir.contains("/test1/file.js")).toBe(true);
+          expect(jsFilesInDir.contains("/test1/file.min.js")).toBe(true);
           expect(jsFilesInDir.contains("/test4/file.js")).toBe(true);
           expect(jsFilesInDir.contains("/test5/file.mustache")).toBe(true);
           expect(jsFilesInDir.contains("/test5/file.json")).toBe(true);
@@ -186,8 +189,9 @@ describe("BundleFiles.", function () {
                                   ""
                               );
 
-          expect(cssFilesInDir.length).toBe(4);
+          expect(cssFilesInDir.length).toBe(5);
           expect(cssFilesInDir.contains("/file.css")).toBe(true);
+          expect(cssFilesInDir.contains("/file.min.css")).toBe(true);
           expect(cssFilesInDir.contains("/file.less")).toBe(true);
           expect(cssFilesInDir.contains("/file.sass")).toBe(true);
           expect(cssFilesInDir.contains("/directory/file.scss")).toBe(true);
@@ -200,8 +204,9 @@ describe("BundleFiles.", function () {
                                   "/test2"
                               );
 
-          expect(cssFilesInDir.length).toBe(4);
+          expect(cssFilesInDir.length).toBe(5);
           expect(cssFilesInDir.contains("/test2/file.css")).toBe(true);
+          expect(cssFilesInDir.contains("/test2/file.min.css")).toBe(true);
           expect(cssFilesInDir.contains("/test2/file.less")).toBe(true);
           expect(cssFilesInDir.contains("/test2/file.sass")).toBe(true);
           expect(cssFilesInDir.contains("/test2/directory/file.scss")).toBe(true);
@@ -214,8 +219,9 @@ describe("BundleFiles.", function () {
                                   ""
                               );
 
-          expect(cssFilesInDir.length).toBe(8);
+          expect(cssFilesInDir.length).toBe(9);
           expect(cssFilesInDir.contains("/test2/file.css")).toBe(true);
+          expect(cssFilesInDir.contains("/test2/file.min.css")).toBe(true);
           expect(cssFilesInDir.contains("/test3/file.css")).toBe(true);
           expect(cssFilesInDir.contains("/test6/file.css")).toBe(true);
       });

--- a/tests/unit/webpack/index-spec.js
+++ b/tests/unit/webpack/index-spec.js
@@ -1,0 +1,130 @@
+var FileType = require('../../../src/file').type;
+var webpack = require('../../../src/webpack');
+
+describe('webpack', function() {
+
+    var files,
+        fileType;
+
+    it('throws when file type is JS and any non-JS files are in the bundle.', function() {
+
+        givenFileTypeIs(FileType.JS);
+        givenFiles(
+            'file1.js',
+            'file1.min.js',
+            'file2.es6'
+        );
+
+        expect(validate).toThrow();
+
+    });
+
+    it('throws when file type is CSS and any non-CSS files are in the bundle.', function() {
+
+        givenFileTypeIs(FileType.CSS);
+        givenFiles(
+            'file1.css',
+            'file1.min.css',
+            'file2.less'
+        );
+
+        expect(validate).toThrow();
+
+    });
+
+    it('throws when file type is JS and any unminified JS files do not have corresponding minified JS file in the bundle.', function() {
+
+        givenFileTypeIs(FileType.JS);
+        givenFiles(
+            'file1.js',
+            'file2.js',
+            'file2.min.js'
+        );
+
+        expect(validate).toThrow();
+
+    });
+
+    it('throws when file type is CSS and any unminified CSS files do not have corresponding minified CSS file in the bundle.', function() {
+
+        givenFileTypeIs(FileType.CSS);
+        givenFiles(
+            'file1.css',
+            'file2.css',
+            'file2.min.css'
+        );
+
+        expect(validate).toThrow();
+
+    });
+
+    it('throws when file type is JS and any minified JS files do not have corresponding unminified JS file in the bundle.', function() {
+
+        givenFileTypeIs(FileType.JS);
+        givenFiles(
+            'file1.js',
+            'file1.min.js',
+            'file2.min.js'
+        );
+
+        expect(validate).toThrow();
+
+    });
+
+    it('throws when file type is CSS and any minified CSS files do not have corresponding unminified CSS file in the bundle.', function() {
+
+        givenFileTypeIs(FileType.CSS);
+        givenFiles(
+            'file1.css',
+            'file1.min.css',
+            'file2.min.css'
+        );
+
+        expect(validate).toThrow();
+
+    });
+
+    it('does not throw when file type is JS and only pairs of unminified and minified JS files are in the bundle.', function() {
+
+        givenFileTypeIs(FileType.JS);
+        givenFiles(
+            'file1.js',
+            'file1.min.js',
+            'file2.js',
+            'file2.min.js'
+        );
+
+        expect(validate).not.toThrow();
+
+    });
+
+    it('does not throw when file type is CSS and only pairs of unminified and minified CSS files are in the bundle.', function() {
+
+        givenFileTypeIs(FileType.CSS);
+        givenFiles(
+            'file1.css',
+            'file1.min.css',
+            'file2.css',
+            'file2.min.css'
+        );
+
+        expect(validate).not.toThrow();
+
+    });
+
+    function validate() {
+        webpack.validate({
+            files: files,
+            fileType: fileType
+        });
+    }
+
+    function givenFiles() {
+        files = Array.prototype.slice.call(arguments);
+    }
+
+    function givenFileTypeIs(type) {
+        fileType = type;
+    }
+
+});


### PR DESCRIPTION
@Laura-Johannet-ZocDoc @Andrew-Hagedorn-ZocDoc 

Changes
--
Added support for bundles of webpack-ed code.

For all the work we're doing in Capi, we have a webpack pipeline for compiling and minifying our code, and we don't want Bundler to do any processing on those files. We also want to be able to load the unminified code in debug mode and the minified code in prod mode.

This PR adds support for a new option in bundles: `#options webpack`. For these bundles, you provide both the unminified and minified files (e.g. `file.js` and `file.min.js`), and Bundler will use each appropriately for debug and prod mode. So in debug mode, only `file.js` will be included in the bundle, while in prod mode, only `file.min.js` will be included. In both cases, no processing is done on the files.